### PR TITLE
Align: clamp auto-align velocity outputs

### DIFF
--- a/src/main/java/org/Griffins1884/frc2026/commands/AutoAlignToPoseCommand.java
+++ b/src/main/java/org/Griffins1884/frc2026/commands/AutoAlignToPoseCommand.java
@@ -135,6 +135,17 @@ public class AutoAlignToPoseCommand extends Command {
     var driveVelocity =
         new Translation2d(driveVelocityScalar, 0.0)
             .rotateBy(currentPose.getTranslation().minus(target.getTranslation()).getAngle());
+    double maxLinearSpeed = AlignConstants.ALIGN_MAX_TRANSLATIONAL_SPEED.get() * constraintFactor;
+    if (driveVelocity.getNorm() > maxLinearSpeed) {
+      driveVelocity = driveVelocity.times(maxLinearSpeed / driveVelocity.getNorm());
+    }
+    thetaVelocity =
+        MathUtil.clamp(
+            thetaVelocity,
+            -AlignConstants.ALIGN_MAX_ANGULAR_SPEED.get(),
+            AlignConstants.ALIGN_MAX_ANGULAR_SPEED.get());
+    Logger.recordOutput("DriveToPose/DriveVelocitySetpoint", driveVelocity);
+    Logger.recordOutput("DriveToPose/ThetaVelocitySetpointRadPerSec", thetaVelocity);
     drive.runVelocity(
         ChassisSpeeds.fromFieldRelativeSpeeds(
             driveVelocity.getX(), driveVelocity.getY(), thetaVelocity, currentPose.getRotation()));


### PR DESCRIPTION
Adds explicit clamping for auto-align commanded chassis speeds: limits translation magnitude to Align MaxTranslationalSpeed * constraintFactor and clamps omega to Align MaxAngularSpeed. Also logs the final setpoints.\n\nFiles:\n- src/main/java/org/Griffins1884/frc2026/commands/AutoAlignToPoseCommand.java\n\nTest: JAVA_HOME=JDK17 ./gradlew test -x spotlessApply -x spotlessJson