### PR TITLE
Build: update WPILib home year to 2026

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,8 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        String frcYear = '2025'
+        // WPILib local Maven repository year (matches the GradleRIO season).
+        String frcYear = '2026'
         File frcHome
         if (OperatingSystem.current().isWindows()) {
             String publicFolder = System.getenv('PUBLIC')


### PR DESCRIPTION
Avoids season crossover in Gradle pluginManagement local WPILib Maven repo path by switching frcYear from 2025 to 2026.\n\nFile:\n- settings.gradle