### PR TITLE
Align: fix climb tag selection and alliance fallback

### DIFF
--- a/src/main/java/org/Griffins1884/frc2026/commands/DriveCommands.java
+++ b/src/main/java/org/Griffins1884/frc2026/commands/DriveCommands.java
@@ -171,29 +171,31 @@ public class DriveCommands {
   public static Command alignToClimbCommand(SwerveSubsystem drive) {
     return Commands.defer(
         () -> {
+          // Prefer alliance (when known). If the DS has not provided alliance yet (sim/offline),
+          // fall back to picking the nearer tower in the blue-origin field coordinate system.
+          boolean isBlue =
+              DriverStation.getAlliance().isPresent()
+                  ? DriverStation.getAlliance().get() == Alliance.Blue
+                  : drive.getPose().getX() < GlobalConstants.FieldConstants.fieldLength / 2.0;
+
           Translation2d target =
-              (DriverStation.getAlliance().isPresent()
-                      && DriverStation.getAlliance().get() == Alliance.Blue)
+              isBlue
                   ? GlobalConstants.FieldConstants.Tower.centerPoint
                   : GlobalConstants.FieldConstants.Tower.oppCenterPoint;
+
+          // Tower wall tags: use the same end-of-field tags that define the tower centerpoint Y.
+          int tagId = isBlue ? 31 : 15;
+
           Rotation2d rotation =
-              (DriverStation.getAlliance().isPresent()
-                      && DriverStation.getAlliance().get() == Alliance.Blue)
-                  ? GlobalConstants.FieldConstants.defaultAprilTagType
-                      .getLayout()
-                      .getTagPose(16)
-                      .get()
-                      .getRotation()
-                      .toRotation2d()
-                  : GlobalConstants.FieldConstants.defaultAprilTagType
-                      .getLayout()
-                      .getTagPose(31)
-                      .get()
-                      .getRotation()
-                      .toRotation2d();
-          Logger.recordOutput("Autonomy/AlignTargetClimb", target);
-          return new AutoAlignToPoseCommand(
-              drive, new Pose2d(target.getX(), target.getY(), rotation));
+              GlobalConstants.FieldConstants.defaultAprilTagType
+                  .getLayout()
+                  .getTagPose(tagId)
+                  .map(tagPose -> tagPose.getRotation().toRotation2d())
+                  // Sensible fallback: point toward the tower along +/-X.
+                  .orElse(isBlue ? new Rotation2d() : new Rotation2d(Math.PI));
+
+          Logger.recordOutput("Autonomy/AlignTargetClimb", new Pose2d(target, rotation));
+          return new AutoAlignToPoseCommand(drive, new Pose2d(target, rotation));
         },
         Set.of(drive));
   }


### PR DESCRIPTION
Fixes climb auto-align selecting the wrong AprilTag IDs for rotation and adds a safe fallback when alliance is unknown (uses pose X to choose the nearer tower).

Notes:
- Uses tower wall tags 31 (blue end) and 15 (red end), matching `GlobalConstants.FieldConstants.Tower` centerpoint definitions.
- Fallback rotation points along +/-X if tag pose is unavailable.

Test:
- `JAVA_HOME=~/.jdks/temurin-17.jdk/Contents/Home ./gradlew test -x spotlessJson` (local; spotlessJson fails locally due to untracked skills JSON)
