### PR TITLE
Swerve: fix Kraken SysId characterization to use voltage

### DIFF
--- a/src/main/java/org/Griffins1884/frc2026/commands/AutoCommands.java
+++ b/src/main/java/org/Griffins1884/frc2026/commands/AutoCommands.java
@@ -1,29 +1,26 @@
 package org.Griffins1884.frc2026.commands;
 
-import com.fasterxml.jackson.databind.util.Named;
-import org.Griffins1884.frc2026.subsystems.Superstructure;
-import org.Griffins1884.frc2026.subsystems.swerve.SwerveSubsystem;
 import com.pathplanner.lib.auto.NamedCommands;
 import edu.wpi.first.wpilibj2.command.Commands;
+import org.Griffins1884.frc2026.subsystems.Superstructure;
+import org.Griffins1884.frc2026.subsystems.swerve.SwerveSubsystem;
 
 public class AutoCommands {
   public static void registerAutoCommands(Superstructure superstructure, SwerveSubsystem drive) {
-    NamedCommands.registerCommand("Shoot",
-            superstructure.setSuperStateCmd(Superstructure.SuperState.SHOOTING));
-
-    NamedCommands.registerCommand("OverBump",
-            superstructure.setSuperStateCmd(Superstructure.SuperState.IDLING));
-
-    NamedCommands.registerCommand("Collect",
-            superstructure.setSuperStateCmd(Superstructure.SuperState.INTAKING));
+    NamedCommands.registerCommand(
+        "Shoot", superstructure.setSuperStateCmd(Superstructure.SuperState.SHOOTING));
 
     NamedCommands.registerCommand(
-            "ShootAndClimb",
-            Commands.sequence(
-                    superstructure.setSuperStateCmd(Superstructure.SuperState.SHOOTING),
-                    DriveCommands.alignToClimbCommand(drive),
-                    superstructure.setSuperStateCmd(Superstructure.SuperState.AUTO_CLIMB)
-            )
-    );
+        "OverBump", superstructure.setSuperStateCmd(Superstructure.SuperState.IDLING));
+
+    NamedCommands.registerCommand(
+        "Collect", superstructure.setSuperStateCmd(Superstructure.SuperState.INTAKING));
+
+    NamedCommands.registerCommand(
+        "ShootAndClimb",
+        Commands.sequence(
+            superstructure.setSuperStateCmd(Superstructure.SuperState.SHOOTING),
+            DriveCommands.alignToClimbCommand(drive),
+            superstructure.setSuperStateCmd(Superstructure.SuperState.AUTO_CLIMB)));
   }
 }

--- a/src/main/java/org/Griffins1884/frc2026/commands/AutoCommands.java
+++ b/src/main/java/org/Griffins1884/frc2026/commands/AutoCommands.java
@@ -1,26 +1,29 @@
 package org.Griffins1884.frc2026.commands;
 
-import com.pathplanner.lib.auto.NamedCommands;
-import edu.wpi.first.wpilibj2.command.Commands;
+import com.fasterxml.jackson.databind.util.Named;
 import org.Griffins1884.frc2026.subsystems.Superstructure;
 import org.Griffins1884.frc2026.subsystems.swerve.SwerveSubsystem;
+import com.pathplanner.lib.auto.NamedCommands;
+import edu.wpi.first.wpilibj2.command.Commands;
 
 public class AutoCommands {
   public static void registerAutoCommands(Superstructure superstructure, SwerveSubsystem drive) {
-    NamedCommands.registerCommand(
-        "Shoot", superstructure.setSuperStateCmd(Superstructure.SuperState.SHOOTING));
+    NamedCommands.registerCommand("Shoot",
+            superstructure.setSuperStateCmd(Superstructure.SuperState.SHOOTING));
+
+    NamedCommands.registerCommand("OverBump",
+            superstructure.setSuperStateCmd(Superstructure.SuperState.IDLING));
+
+    NamedCommands.registerCommand("Collect",
+            superstructure.setSuperStateCmd(Superstructure.SuperState.INTAKING));
 
     NamedCommands.registerCommand(
-        "OverBump", superstructure.setSuperStateCmd(Superstructure.SuperState.IDLING));
-
-    NamedCommands.registerCommand(
-        "Collect", superstructure.setSuperStateCmd(Superstructure.SuperState.INTAKING));
-
-    NamedCommands.registerCommand(
-        "ShootAndClimb",
-        Commands.sequence(
-            superstructure.setSuperStateCmd(Superstructure.SuperState.SHOOTING),
-            DriveCommands.alignToClimbCommand(drive),
-            superstructure.setSuperStateCmd(Superstructure.SuperState.AUTO_CLIMB)));
+            "ShootAndClimb",
+            Commands.sequence(
+                    superstructure.setSuperStateCmd(Superstructure.SuperState.SHOOTING),
+                    DriveCommands.alignToClimbCommand(drive),
+                    superstructure.setSuperStateCmd(Superstructure.SuperState.AUTO_CLIMB)
+            )
+    );
   }
 }

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/swerve/Module.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/swerve/Module.java
@@ -187,7 +187,21 @@ public class Module {
     return inputs.driveVelocityRadPerSec;
   }
 
-  public double getVoltage() {
+  public double getDriveVoltage() {
     return inputs.driveAppliedVolts;
+  }
+
+  public double getTurnVoltage() {
+    return inputs.turnAppliedVolts;
+  }
+
+  /** Returns the current module turn position in radians. */
+  public double getTurnPositionRad() {
+    return inputs.turnPosition.getRadians();
+  }
+
+  /** Returns the current module turn velocity in rad/sec. */
+  public double getTurnVelocityRadPerSec() {
+    return inputs.turnVelocityRadPerSec;
   }
 }

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/swerve/ModuleIOFullKraken.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/swerve/ModuleIOFullKraken.java
@@ -60,7 +60,7 @@ public class ModuleIOFullKraken implements ModuleIO {
   private static final Executor brakeModeExecutor = Executors.newFixedThreadPool(8);
 
   // Control requests
-  private final TorqueCurrentFOC torqueCurrentRequest = new TorqueCurrentFOC(0).withUpdateFreqHz(0);
+  private final VoltageOut voltageOutRequest = new VoltageOut(0.0).withUpdateFreqHz(0);
   private final PositionTorqueCurrentFOC positionTorqueCurrentRequest =
       new PositionTorqueCurrentFOC(0.0).withUpdateFreqHz(0);
   private final VelocityTorqueCurrentFOC velocityTorqueCurrentRequest =
@@ -295,12 +295,13 @@ public class ModuleIOFullKraken implements ModuleIO {
 
   @Override
   public void setDriveOpenLoop(double output) {
-    driveMotor.setControl(torqueCurrentRequest.withOutput(output));
+    // Characterization (SysId + FF characterization) expects voltage control.
+    driveMotor.setControl(voltageOutRequest.withOutput(output));
   }
 
   @Override
   public void setTurnOpenLoop(double output) {
-    turnMotor.setControl(torqueCurrentRequest.withOutput(output));
+    turnMotor.setControl(voltageOutRequest.withOutput(output));
   }
 
   @Override

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/swerve/SwerveSubsystem.java
@@ -63,7 +63,7 @@ import org.littletonrobotics.junction.AutoLogOutput;
 import org.littletonrobotics.junction.Logger;
 
 public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsumer {
-  private static final double DRIVE_SYS_ID_MAX_VOLTAGE = 40.0;
+  private static final double DRIVE_SYS_ID_MAX_VOLTAGE = 12.0;
   private static final double TURN_SYS_ID_MAX_VOLTAGE = 12.0;
   private static final double SYS_ID_IDLE_WAIT_SECONDS = 0.5;
 
@@ -149,7 +149,7 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
           for (int i = 0; i < 4; i++) {
             Module module = modules[i];
             log.motor("DriveM" + i)
-                .voltage(Volts.of(module.getVoltage()))
+                .voltage(Volts.of(module.getDriveVoltage()))
                 .angularVelocity(RadiansPerSecond.of(module.getFFCharacterizationVelocity()))
                 .angularPosition(Radian.of(module.getWheelRadiusCharacterizationPosition()));
           }
@@ -161,9 +161,9 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
           for (int i = 0; i < 4; i++) {
             Module module = modules[i];
             log.motor("TurnM" + i)
-                .voltage(Volts.of(module.getVoltage()))
-                .angularVelocity(RadiansPerSecond.of(module.getFFCharacterizationVelocity()))
-                .angularPosition(Radian.of(module.getWheelRadiusCharacterizationPosition()));
+                .voltage(Volts.of(module.getTurnVoltage()))
+                .angularVelocity(RadiansPerSecond.of(module.getTurnVelocityRadPerSec()))
+                .angularPosition(Radian.of(module.getTurnPositionRad()));
           }
         };
 


### PR DESCRIPTION
- Kraken `setDriveOpenLoop`/`setTurnOpenLoop` now use `VoltageOut` so SysId + characterization are actually voltage-based.
- Drive SysId max voltage corrected to 12V.
- Turn SysId logging fixed: previously logged drive voltage/drive sensors for the turn test.

Test:
- `JAVA_HOME=~/.jdks/temurin-17.jdk/Contents/Home ./gradlew test -x spotlessJson`
