### PR TITLE
OperatorBoard: add 2026 hub shift tracker

### DIFF
--- a/src/main/java/org/Griffins1884/frc2026/subsystems/objectivetracker/OperatorBoardContract.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/objectivetracker/OperatorBoardContract.java
@@ -21,6 +21,15 @@ final class OperatorBoardContract {
   static final String BROWNOUT = "Brownout";
   static final String ALLIANCE = "Alliance";
   static final String MATCH_TIME = "MatchTime";
+  static final String HUB_TIMEFRAME = "HubTimeframe";
+  static final String HUB_STATUS_VALID = "HubStatusValid";
+  static final String RED_HUB_STATUS = "RedHubStatus";
+  static final String BLUE_HUB_STATUS = "BlueHubStatus";
+  static final String OUR_HUB_STATUS = "OurHubStatus";
+  static final String OUR_HUB_ACTIVE = "OurHubActive";
+  static final String AUTO_WINNER_ALLIANCE = "AutoWinnerAlliance";
+  static final String GAME_DATA_RAW = "GameDataRaw";
+  static final String HUB_RECOMMENDATION = "HubRecommendation";
   static final String TURRET_AT_SETPOINT = "TurretAtSetpoint";
   static final String TURRET_MODE = "TurretMode";
   static final String VISION_STATUS = "VisionStatus";

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/objectivetracker/OperatorBoardIO.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/objectivetracker/OperatorBoardIO.java
@@ -49,6 +49,24 @@ public interface OperatorBoardIO {
 
   default void setMatchTime(double value) {}
 
+  default void setHubTimeframe(String value) {}
+
+  default void setHubStatusValid(boolean value) {}
+
+  default void setRedHubStatus(String value) {}
+
+  default void setBlueHubStatus(String value) {}
+
+  default void setOurHubStatus(String value) {}
+
+  default void setOurHubActive(boolean value) {}
+
+  default void setAutoWinnerAlliance(String value) {}
+
+  default void setGameDataRaw(String value) {}
+
+  default void setHubRecommendation(String value) {}
+
   default void setTurretAtSetpoint(boolean value) {}
 
   default void setTurretMode(String value) {}

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/objectivetracker/OperatorBoardIOServer.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/objectivetracker/OperatorBoardIOServer.java
@@ -35,6 +35,15 @@ public class OperatorBoardIOServer implements OperatorBoardIO {
   private final BooleanPublisher brownoutOut;
   private final StringPublisher allianceOut;
   private final DoublePublisher matchTimeOut;
+  private final StringPublisher hubTimeframeOut;
+  private final BooleanPublisher hubStatusValidOut;
+  private final StringPublisher redHubStatusOut;
+  private final StringPublisher blueHubStatusOut;
+  private final StringPublisher ourHubStatusOut;
+  private final BooleanPublisher ourHubActiveOut;
+  private final StringPublisher autoWinnerAllianceOut;
+  private final StringPublisher gameDataRawOut;
+  private final StringPublisher hubRecommendationOut;
   private final BooleanPublisher turretAtSetpointOut;
   private final StringPublisher turretModeOut;
   private final StringPublisher visionStatusOut;
@@ -66,6 +75,18 @@ public class OperatorBoardIOServer implements OperatorBoardIO {
     brownoutOut = outputTable.getBooleanTopic(OperatorBoardContract.BROWNOUT).publish();
     allianceOut = outputTable.getStringTopic(OperatorBoardContract.ALLIANCE).publish();
     matchTimeOut = outputTable.getDoubleTopic(OperatorBoardContract.MATCH_TIME).publish();
+    hubTimeframeOut = outputTable.getStringTopic(OperatorBoardContract.HUB_TIMEFRAME).publish();
+    hubStatusValidOut =
+        outputTable.getBooleanTopic(OperatorBoardContract.HUB_STATUS_VALID).publish();
+    redHubStatusOut = outputTable.getStringTopic(OperatorBoardContract.RED_HUB_STATUS).publish();
+    blueHubStatusOut = outputTable.getStringTopic(OperatorBoardContract.BLUE_HUB_STATUS).publish();
+    ourHubStatusOut = outputTable.getStringTopic(OperatorBoardContract.OUR_HUB_STATUS).publish();
+    ourHubActiveOut = outputTable.getBooleanTopic(OperatorBoardContract.OUR_HUB_ACTIVE).publish();
+    autoWinnerAllianceOut =
+        outputTable.getStringTopic(OperatorBoardContract.AUTO_WINNER_ALLIANCE).publish();
+    gameDataRawOut = outputTable.getStringTopic(OperatorBoardContract.GAME_DATA_RAW).publish();
+    hubRecommendationOut =
+        outputTable.getStringTopic(OperatorBoardContract.HUB_RECOMMENDATION).publish();
     turretAtSetpointOut =
         outputTable.getBooleanTopic(OperatorBoardContract.TURRET_AT_SETPOINT).publish();
     turretModeOut = outputTable.getStringTopic(OperatorBoardContract.TURRET_MODE).publish();
@@ -158,6 +179,51 @@ public class OperatorBoardIOServer implements OperatorBoardIO {
   @Override
   public void setMatchTime(double value) {
     matchTimeOut.set(value);
+  }
+
+  @Override
+  public void setHubTimeframe(String value) {
+    hubTimeframeOut.set(value == null ? "" : value);
+  }
+
+  @Override
+  public void setHubStatusValid(boolean value) {
+    hubStatusValidOut.set(value);
+  }
+
+  @Override
+  public void setRedHubStatus(String value) {
+    redHubStatusOut.set(value == null ? "" : value);
+  }
+
+  @Override
+  public void setBlueHubStatus(String value) {
+    blueHubStatusOut.set(value == null ? "" : value);
+  }
+
+  @Override
+  public void setOurHubStatus(String value) {
+    ourHubStatusOut.set(value == null ? "" : value);
+  }
+
+  @Override
+  public void setOurHubActive(boolean value) {
+    ourHubActiveOut.set(value);
+  }
+
+  @Override
+  public void setAutoWinnerAlliance(String value) {
+    autoWinnerAllianceOut.set(value == null ? "" : value);
+  }
+
+  @Override
+  public void setGameDataRaw(String value) {
+    gameDataRawOut.set(value == null ? "" : value);
+  }
+
+  @Override
+  public void setHubRecommendation(String value) {
+    hubRecommendationOut.set(value == null ? "" : value);
   }
 
   @Override

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/objectivetracker/OperatorBoardTracker.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/objectivetracker/OperatorBoardTracker.java
@@ -28,6 +28,7 @@ import org.Griffins1884.frc2026.subsystems.Superstructure;
 import org.Griffins1884.frc2026.subsystems.Superstructure.SuperState;
 import org.Griffins1884.frc2026.subsystems.swerve.SwerveSubsystem;
 import org.Griffins1884.frc2026.subsystems.turret.TurretSubsystem;
+import org.Griffins1884.frc2026.util.HubShiftTracker;
 import org.littletonrobotics.junction.Logger;
 
 public class OperatorBoardTracker extends SubsystemBase implements AutoCloseable {
@@ -167,6 +168,18 @@ public class OperatorBoardTracker extends SubsystemBase implements AutoCloseable
     io.setBrownout(RobotController.isBrownedOut());
     io.setAlliance(getAlliance());
     io.setMatchTime(DriverStation.getMatchTime());
+
+    HubShiftTracker.Snapshot hubSnapshot = HubShiftTracker.fromDriverStation();
+    io.setHubTimeframe(hubSnapshot.timeframe().name());
+    io.setHubStatusValid(hubSnapshot.hubStatusValid());
+    io.setRedHubStatus(hubSnapshot.redHubStatus().name());
+    io.setBlueHubStatus(hubSnapshot.blueHubStatus().name());
+    io.setOurHubStatus(hubSnapshot.ourHubStatus().name());
+    io.setOurHubActive(hubSnapshot.ourHubActive());
+    io.setAutoWinnerAlliance(
+        hubSnapshot.autoWinner().isPresent() ? hubSnapshot.autoWinner().get().name() : "UNKNOWN");
+    io.setGameDataRaw(hubSnapshot.gameDataRaw());
+    io.setHubRecommendation(hubSnapshot.recommendation());
 
     io.setTurretAtSetpoint(turret != null && turret.isAtGoal());
     io.setTurretMode(turret != null ? turret.getControlMode().name() : "UNAVAILABLE");

--- a/src/main/java/org/Griffins1884/frc2026/util/HubShiftTracker.java
+++ b/src/main/java/org/Griffins1884/frc2026/util/HubShiftTracker.java
@@ -1,0 +1,200 @@
+package org.Griffins1884.frc2026.util;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Implements 2026 REBUILT hub-active shifting rules.
+ *
+ * <p>Manual summary:
+ *
+ * <ul>
+ *   <li>AUTO, TRANSITION SHIFT, and END GAME: both hubs active.
+ *   <li>SHIFT 1-4: exactly one hub is active.
+ *   <li>The alliance that scored more fuel in AUTO has their hub inactive for SHIFT 1.
+ *   <li>Hub activeness alternates at the start of each subsequent alliance shift.
+ * </ul>
+ */
+public final class HubShiftTracker {
+  public enum MatchTimeframe {
+    AUTO,
+    TRANSITION,
+    SHIFT_1,
+    SHIFT_2,
+    SHIFT_3,
+    SHIFT_4,
+    ENDGAME,
+    UNKNOWN
+  }
+
+  public enum HubStatus {
+    ACTIVE,
+    INACTIVE,
+    UNKNOWN
+  }
+
+  public record Snapshot(
+      MatchTimeframe timeframe,
+      boolean hubStatusValid,
+      Optional<DriverStation.Alliance> autoWinner,
+      HubStatus redHubStatus,
+      HubStatus blueHubStatus,
+      Optional<DriverStation.Alliance> ourAlliance,
+      HubStatus ourHubStatus,
+      boolean ourHubActive,
+      String gameDataRaw,
+      String recommendation) {}
+
+  private HubShiftTracker() {}
+
+  public static Snapshot fromDriverStation() {
+    String gameData = DriverStation.getGameSpecificMessage();
+    Optional<DriverStation.Alliance> autoWinner = parseAutoWinner(gameData);
+    return compute(
+        DriverStation.isAutonomous(),
+        DriverStation.isTeleop(),
+        DriverStation.getMatchTime(),
+        DriverStation.getAlliance(),
+        autoWinner,
+        gameData);
+  }
+
+  public static Snapshot compute(
+      boolean isAutonomous,
+      boolean isTeleop,
+      double matchTimeSeconds,
+      Optional<DriverStation.Alliance> ourAlliance,
+      Optional<DriverStation.Alliance> autoWinner,
+      String gameDataRaw) {
+    MatchTimeframe timeframe = computeTimeframe(isAutonomous, isTeleop, matchTimeSeconds);
+
+    HubStatus red = HubStatus.UNKNOWN;
+    HubStatus blue = HubStatus.UNKNOWN;
+    boolean valid = false;
+
+    if (timeframe == MatchTimeframe.AUTO
+        || timeframe == MatchTimeframe.TRANSITION
+        || timeframe == MatchTimeframe.ENDGAME) {
+      red = HubStatus.ACTIVE;
+      blue = HubStatus.ACTIVE;
+      valid = true;
+    } else if (timeframe == MatchTimeframe.SHIFT_1
+        || timeframe == MatchTimeframe.SHIFT_2
+        || timeframe == MatchTimeframe.SHIFT_3
+        || timeframe == MatchTimeframe.SHIFT_4) {
+      if (autoWinner.isPresent()) {
+        int shiftNumber =
+            switch (timeframe) {
+              case SHIFT_1 -> 1;
+              case SHIFT_2 -> 2;
+              case SHIFT_3 -> 3;
+              case SHIFT_4 -> 4;
+              default -> 0;
+            };
+        boolean winnerInactiveThisShift = (shiftNumber % 2) == 1; // winner inactive on SHIFT 1/3
+        if (autoWinner.get() == DriverStation.Alliance.Red) {
+          red = winnerInactiveThisShift ? HubStatus.INACTIVE : HubStatus.ACTIVE;
+          blue = winnerInactiveThisShift ? HubStatus.ACTIVE : HubStatus.INACTIVE;
+        } else {
+          blue = winnerInactiveThisShift ? HubStatus.INACTIVE : HubStatus.ACTIVE;
+          red = winnerInactiveThisShift ? HubStatus.ACTIVE : HubStatus.INACTIVE;
+        }
+        valid = true;
+      }
+    }
+
+    HubStatus ourHub = HubStatus.UNKNOWN;
+    if (ourAlliance.isPresent()) {
+      ourHub = ourAlliance.get() == DriverStation.Alliance.Red ? red : blue;
+    }
+    boolean ourHubActive = ourHub == HubStatus.ACTIVE;
+
+    String recommendation = computeRecommendation(timeframe, ourHub, valid);
+
+    return new Snapshot(
+        timeframe,
+        valid,
+        autoWinner,
+        red,
+        blue,
+        ourAlliance,
+        ourHub,
+        ourHubActive,
+        gameDataRaw == null ? "" : gameDataRaw,
+        recommendation);
+  }
+
+  public static MatchTimeframe computeTimeframe(
+      boolean isAutonomous, boolean isTeleop, double matchTimeSeconds) {
+    if (isAutonomous) {
+      return MatchTimeframe.AUTO;
+    }
+    if (!isTeleop || !Double.isFinite(matchTimeSeconds) || matchTimeSeconds < 0.0) {
+      return MatchTimeframe.UNKNOWN;
+    }
+
+    // TELEOP timer values from the manual:
+    // Transition: 2:20-2:10 (140-130)
+    // Shift1: 2:10-1:45 (130-105)
+    // Shift2: 1:45-1:20 (105-80)
+    // Shift3: 1:20-0:55 (80-55)
+    // Shift4: 0:55-0:30 (55-30)
+    // Endgame: 0:30-0:00 (30-0)
+    if (matchTimeSeconds > 130.0) return MatchTimeframe.TRANSITION;
+    if (matchTimeSeconds > 105.0) return MatchTimeframe.SHIFT_1;
+    if (matchTimeSeconds > 80.0) return MatchTimeframe.SHIFT_2;
+    if (matchTimeSeconds > 55.0) return MatchTimeframe.SHIFT_3;
+    if (matchTimeSeconds > 30.0) return MatchTimeframe.SHIFT_4;
+    return MatchTimeframe.ENDGAME;
+  }
+
+  public static Optional<DriverStation.Alliance> parseAutoWinner(String gameSpecificMessage) {
+    if (gameSpecificMessage == null) {
+      return Optional.empty();
+    }
+    String raw = gameSpecificMessage.trim();
+    if (raw.isEmpty()) {
+      return Optional.empty();
+    }
+    String upper = raw.toUpperCase(Locale.ROOT);
+
+    // Common cases are "R" or "B". Be conservative to avoid false positives.
+    boolean mentionsRed =
+        upper.equals("R")
+            || upper.equals("RED")
+            || upper.contains(" RED ")
+            || upper.startsWith("RED")
+            || upper.endsWith("RED")
+            || upper.contains("RED:")
+            || upper.contains("RED=");
+    boolean mentionsBlue =
+        upper.equals("B")
+            || upper.equals("BLUE")
+            || upper.contains(" BLUE ")
+            || upper.startsWith("BLUE")
+            || upper.endsWith("BLUE")
+            || upper.contains("BLUE:")
+            || upper.contains("BLUE=");
+
+    if (mentionsRed == mentionsBlue) {
+      return Optional.empty();
+    }
+    return Optional.of(mentionsRed ? DriverStation.Alliance.Red : DriverStation.Alliance.Blue);
+  }
+
+  private static String computeRecommendation(
+      MatchTimeframe timeframe, HubStatus ourHub, boolean hubStatusValid) {
+    if (timeframe == MatchTimeframe.UNKNOWN) {
+      return "UNKNOWN";
+    }
+    if (timeframe == MatchTimeframe.ENDGAME) {
+      return "SCORE OR CLIMB";
+    }
+    if (!hubStatusValid) {
+      return "CHECK FMS";
+    }
+    return ourHub == HubStatus.ACTIVE ? "SCORE" : "COLLECT/FERRY/DEFEND";
+  }
+}
+

--- a/src/test/java/org/Griffins1884/frc2026/util/HubShiftTrackerTest.java
+++ b/src/test/java/org/Griffins1884/frc2026/util/HubShiftTrackerTest.java
@@ -1,0 +1,83 @@
+package org.Griffins1884.frc2026.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import java.util.Optional;
+import org.Griffins1884.frc2026.util.HubShiftTracker.HubStatus;
+import org.Griffins1884.frc2026.util.HubShiftTracker.MatchTimeframe;
+import org.junit.jupiter.api.Test;
+
+public class HubShiftTrackerTest {
+  @Test
+  void teleopTimeframes_matchTableBoundaries() {
+    assertEquals(
+        MatchTimeframe.TRANSITION,
+        HubShiftTracker.computeTimeframe(false, true, 135.0),
+        "135s should be TRANSITION");
+    assertEquals(
+        MatchTimeframe.SHIFT_1,
+        HubShiftTracker.computeTimeframe(false, true, 130.0),
+        "130s should be SHIFT_1");
+    assertEquals(
+        MatchTimeframe.SHIFT_2,
+        HubShiftTracker.computeTimeframe(false, true, 105.0),
+        "105s should be SHIFT_2");
+    assertEquals(
+        MatchTimeframe.SHIFT_3,
+        HubShiftTracker.computeTimeframe(false, true, 80.0),
+        "80s should be SHIFT_3");
+    assertEquals(
+        MatchTimeframe.SHIFT_4,
+        HubShiftTracker.computeTimeframe(false, true, 55.0),
+        "55s should be SHIFT_4");
+    assertEquals(
+        MatchTimeframe.ENDGAME,
+        HubShiftTracker.computeTimeframe(false, true, 30.0),
+        "30s should be ENDGAME");
+  }
+
+  @Test
+  void allianceShifts_alternateBasedOnAutoWinner_redWinner() {
+    Optional<DriverStation.Alliance> ourAlliance = Optional.of(DriverStation.Alliance.Red);
+    Optional<DriverStation.Alliance> winner = Optional.of(DriverStation.Alliance.Red);
+
+    var s1 =
+        HubShiftTracker.compute(false, true, 129.0, ourAlliance, winner, "R"); // SHIFT_1
+    assertTrue(s1.hubStatusValid());
+    assertEquals(HubStatus.INACTIVE, s1.redHubStatus());
+    assertEquals(HubStatus.ACTIVE, s1.blueHubStatus());
+    assertFalse(s1.ourHubActive());
+
+    var s2 = HubShiftTracker.compute(false, true, 104.0, ourAlliance, winner, "R");
+    assertTrue(s2.hubStatusValid());
+    assertEquals(HubStatus.ACTIVE, s2.redHubStatus());
+    assertEquals(HubStatus.INACTIVE, s2.blueHubStatus());
+    assertTrue(s2.ourHubActive());
+
+    var s3 = HubShiftTracker.compute(false, true, 79.0, ourAlliance, winner, "R");
+    assertTrue(s3.hubStatusValid());
+    assertEquals(HubStatus.INACTIVE, s3.redHubStatus());
+    assertEquals(HubStatus.ACTIVE, s3.blueHubStatus());
+    assertFalse(s3.ourHubActive());
+
+    var s4 = HubShiftTracker.compute(false, true, 54.0, ourAlliance, winner, "R");
+    assertTrue(s4.hubStatusValid());
+    assertEquals(HubStatus.ACTIVE, s4.redHubStatus());
+    assertEquals(HubStatus.INACTIVE, s4.blueHubStatus());
+    assertTrue(s4.ourHubActive());
+  }
+
+  @Test
+  void allianceShifts_unknownWinner_isInvalid() {
+    Optional<DriverStation.Alliance> ourAlliance = Optional.of(DriverStation.Alliance.Blue);
+    var snapshot = HubShiftTracker.compute(false, true, 129.0, ourAlliance, Optional.empty(), "");
+    assertFalse(snapshot.hubStatusValid());
+    assertEquals(HubStatus.UNKNOWN, snapshot.redHubStatus());
+    assertEquals(HubStatus.UNKNOWN, snapshot.blueHubStatus());
+    assertFalse(snapshot.ourHubActive());
+  }
+}
+


### PR DESCRIPTION
Implements 2026 REBUILT hub shifting rules (AUTO/TRANSITION/ENDGAME both active; SHIFT 1-4 alternate based on AUTO winner) and publishes the results to OperatorBoard NT topics.

Adds `HubShiftTracker` + unit tests, and publishes `HubTimeframe`, hub statuses, AUTO winner, raw game data, and a simple recommendation string.