### PR TITLE
OperatorBoard: show hub shift and recommendation

### DIFF
--- a/src/main/deploy/operatorboard/index.css
+++ b/src/main/deploy/operatorboard/index.css
@@ -246,6 +246,18 @@ body {
   font-weight: 800;
 }
 
+.tile__v--ok {
+  color: var(--ok);
+}
+
+.tile__v--bad {
+  color: var(--bad);
+}
+
+.tile__v--warn {
+  color: var(--warn);
+}
+
 .tile__v--mono {
   font-family: var(--mono);
   font-size: 12px;
@@ -261,4 +273,3 @@ body {
     min-height: 360px;
   }
 }
-

--- a/src/main/deploy/operatorboard/index.html
+++ b/src/main/deploy/operatorboard/index.html
@@ -68,6 +68,18 @@
             <div id="match-time" class="tile__v">--</div>
           </div>
           <div class="tile">
+            <div class="tile__k">Hub Shift</div>
+            <div id="hub-timeframe" class="tile__v">--</div>
+          </div>
+          <div class="tile">
+            <div class="tile__k">Our Hub</div>
+            <div id="our-hub" class="tile__v">--</div>
+          </div>
+          <div class="tile tile--wide">
+            <div class="tile__k">Recommendation</div>
+            <div id="hub-recommendation" class="tile__v">--</div>
+          </div>
+          <div class="tile">
             <div class="tile__k">Battery</div>
             <div id="battery" class="tile__v">--</div>
           </div>
@@ -99,6 +111,10 @@
             <div class="tile__k">Target</div>
             <div id="target" class="tile__v tile__v--mono">--</div>
           </div>
+          <div class="tile tile--wide">
+            <div class="tile__k">FMS Hub Data</div>
+            <div id="hub-fms" class="tile__v tile__v--mono">--</div>
+          </div>
         </div>
       </section>
     </main>
@@ -106,4 +122,3 @@
     <script type="module" src="./index.js"></script>
   </body>
 </html>
-


### PR DESCRIPTION
Updates OperatorBoard UI to display hub shift timeframe, our hub active/inactive status, a simple recommendation string, and raw FMS hub data (auto winner + hub statuses).\n\nRequires the hub-shift NT topics from PR #54.