### PR TITLE
Vision: multi-camera arbitration with robust logging and tests

### DIFF
--- a/src/main/java/org/Griffins1884/frc2026/subsystems/vision/AprilTagVisionConstants.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/vision/AprilTagVisionConstants.java
@@ -113,6 +113,10 @@ public final class AprilTagVisionConstants {
       new LoggedTunableNumber("AprilTagVision/Limelight/SingleTagQualityCutoff", 0.3);
   private static final LoggedTunableNumber LIMELIGHT_MAX_YAW_RATE_DEG_PER_SEC =
       new LoggedTunableNumber("AprilTagVision/Limelight/MaxYawRateDegPerSec", 180.0);
+  private static final LoggedTunableNumber LIMELIGHT_MULTI_CAM_MAX_DELTA_METERS =
+      new LoggedTunableNumber("AprilTagVision/Limelight/MultiCam/MaxDeltaMeters", 0.75);
+  private static final LoggedTunableNumber LIMELIGHT_MULTI_CAM_MAX_DELTA_DEG =
+      new LoggedTunableNumber("AprilTagVision/Limelight/MultiCam/MaxDeltaDeg", 20.0);
   private static final LoggedTunableNumber FIELD_BORDER_MARGIN_METERS =
       new LoggedTunableNumber("AprilTagVision/FieldBorderMarginMeters", 0.5);
   public static final int LIMELIGHT_MEGATAG1_X_STDDEV_INDEX = 0;
@@ -169,6 +173,14 @@ public final class AprilTagVisionConstants {
 
   public static double getLimelightMaxYawRateDegPerSec() {
     return LIMELIGHT_MAX_YAW_RATE_DEG_PER_SEC.get();
+  }
+
+  public static double getLimelightMultiCamMaxDeltaMeters() {
+    return LIMELIGHT_MULTI_CAM_MAX_DELTA_METERS.get();
+  }
+
+  public static double getLimelightMultiCamMaxDeltaDeg() {
+    return LIMELIGHT_MULTI_CAM_MAX_DELTA_DEG.get();
   }
 
   public static double getFieldBorderMarginMeters() {

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/vision/Vision.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/vision/Vision.java
@@ -18,9 +18,12 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 import lombok.Setter;
@@ -38,6 +41,7 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
   private final PoseHistory poseHistory;
   @Setter private boolean useVision = true;
   private final DoubleSupplier yawRateRadPerSecSupplier;
+  private final Set<String> lastArbitrationPairKeys = new HashSet<>();
 
   /**
    * Creates a Vision system for PhotonVision inputs.
@@ -269,7 +273,7 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
     Logger.recordOutput("Vision/yawRateDegPerSec", yawRateDegPerSec);
     Logger.recordOutput("Vision/yawRateAccept", yawRateOk);
 
-    List<Optional<VisionFieldPoseEstimate>> estimates = new ArrayList<>();
+    List<LimelightEstimateCandidate> candidates = new ArrayList<>();
 
     for (int i = 0; i < io.length; i++) {
       io[i].updateInputs(inputs[i]);
@@ -279,10 +283,18 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
       String cameraLabel = io[i].getCameraConstants().cameraName();
       logCameraInputs("Vision/" + cameraLabel, inputs[i]);
       logLimelightDiagnostics(cameraLabel, inputs[i]);
-      estimates.add(buildLimelightEstimate(inputs[i]));
+      buildLimelightCandidate(cameraLabel, inputs[i]).ifPresent(candidates::add);
     }
 
     if (!useVision) {
+      logArbitration(
+          new ArbitrationResult(
+              ArbitrationMode.NONE,
+              candidates.size(),
+              0,
+              "VISION_DISABLED",
+              Optional.empty(),
+              List.of()));
       Logger.recordOutput("Vision/usingVision", false);
       Logger.recordOutput("Vision/rejectReason", "VISION_DISABLED");
       Logger.recordOutput("Vision/latencyPeriodicSec", Timer.getFPGATimestamp() - startTime);
@@ -290,6 +302,14 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
     }
 
     if (!yawRateOk) {
+      logArbitration(
+          new ArbitrationResult(
+              ArbitrationMode.NONE,
+              candidates.size(),
+              0,
+              "HIGH_YAW_RATE",
+              Optional.empty(),
+              List.of()));
       Logger.recordOutput("Vision/usingVision", true);
       Logger.recordOutput("Vision/rejectReason", "HIGH_YAW_RATE");
       Logger.recordOutput("Vision/latencyPeriodicSec", Timer.getFPGATimestamp() - startTime);
@@ -299,29 +319,24 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
     Logger.recordOutput("Vision/usingVision", true);
     Logger.recordOutput("Vision/rejectReason", "ACCEPTED");
 
-    Optional<VisionFieldPoseEstimate> accepted = Optional.empty();
-    for (Optional<VisionFieldPoseEstimate> estimate : estimates) {
-      if (estimate.isEmpty()) {
-        continue;
-      }
-      if (accepted.isEmpty()) {
-        accepted = estimate;
-      } else {
-        accepted = Optional.of(fuseEstimates(accepted.get(), estimate.get()));
-      }
-    }
-
-    accepted.ifPresent(
-        est -> {
-          Logger.recordOutput("Vision/fusedAccepted", est.visionRobotPoseMeters());
-          consumer.accept(
-              est.visionRobotPoseMeters(), est.timestampSeconds(), est.visionMeasurementStdDevs());
-        });
+    ArbitrationResult arbitration = arbitrateCandidates(candidates);
+    logArbitration(arbitration);
+    arbitration
+        .estimate()
+        .ifPresent(
+            est -> {
+              Logger.recordOutput("Vision/fusedAccepted", est.visionRobotPoseMeters());
+              consumer.accept(
+                  est.visionRobotPoseMeters(),
+                  est.timestampSeconds(),
+                  est.visionMeasurementStdDevs());
+            });
 
     Logger.recordOutput("Vision/latencyPeriodicSec", Timer.getFPGATimestamp() - startTime);
   }
 
-  private Optional<VisionFieldPoseEstimate> buildLimelightEstimate(VisionIO.VisionIOInputs cam) {
+  private Optional<LimelightEstimateCandidate> buildLimelightCandidate(
+      String cameraLabel, VisionIO.VisionIOInputs cam) {
     if (!cam.connected || cam.megatagPoseEstimate == null) {
       return Optional.empty();
     }
@@ -352,32 +367,199 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
       thetaStd = AprilTagVisionConstants.getLimelightLargeVariance();
     }
     Matrix<N3, N1> visionStdDevs = VecBuilder.fill(stdDevs.x(), stdDevs.y(), thetaStd);
+    int numTags = cam.megatagPoseEstimate.fiducialIds().length;
+    double score =
+        computeCandidateScore(
+            numTags,
+            qualityUsed,
+            cam.megatagPoseEstimate.avgTagArea(),
+            stdDevs.x(),
+            stdDevs.y(),
+            thetaStd);
 
     return Optional.of(
-        new VisionFieldPoseEstimate(
-            fieldToRobot, cam.megatagPoseEstimate.timestampSeconds(), visionStdDevs, tagCount));
+        new LimelightEstimateCandidate(
+            cameraLabel,
+            new VisionFieldPoseEstimate(
+                fieldToRobot, cam.megatagPoseEstimate.timestampSeconds(), visionStdDevs, numTags),
+            score));
+  }
+
+  private ArbitrationResult arbitrateCandidates(List<LimelightEstimateCandidate> candidates) {
+    if (candidates.isEmpty()) {
+      return new ArbitrationResult(ArbitrationMode.NONE, 0, 0, "", Optional.empty(), List.of());
+    }
+    if (candidates.size() == 1) {
+      LimelightEstimateCandidate only = candidates.get(0);
+      return new ArbitrationResult(
+          ArbitrationMode.SINGLE,
+          1,
+          1,
+          only.cameraLabel(),
+          Optional.of(only.estimate()),
+          List.of());
+    }
+
+    List<CameraPairDelta> pairDeltas = new ArrayList<>();
+    boolean allConsistent = true;
+    for (int i = 0; i < candidates.size(); i++) {
+      for (int j = i + 1; j < candidates.size(); j++) {
+        CameraPairDelta delta = compareCandidates(candidates.get(i), candidates.get(j), i, j);
+        pairDeltas.add(delta);
+        allConsistent &= delta.consistent();
+      }
+    }
+
+    int consistentGroupSize = computeLargestConsistentGroupSize(candidates, pairDeltas);
+    if (allConsistent) {
+      List<LimelightEstimateCandidate> ordered = new ArrayList<>(candidates);
+      ordered.sort(
+          Comparator.comparingDouble(candidate -> candidate.estimate().timestampSeconds()));
+      VisionFieldPoseEstimate fused = ordered.get(0).estimate();
+      for (int i = 1; i < ordered.size(); i++) {
+        fused = fuseEstimates(fused, ordered.get(i).estimate());
+      }
+      return new ArbitrationResult(
+          ArbitrationMode.FUSED,
+          candidates.size(),
+          consistentGroupSize,
+          "FUSED",
+          Optional.of(fused),
+          pairDeltas);
+    }
+
+    LimelightEstimateCandidate best = chooseBestCandidate(candidates);
+    return new ArbitrationResult(
+        ArbitrationMode.FALLBACK_SINGLE,
+        candidates.size(),
+        consistentGroupSize,
+        best.cameraLabel(),
+        Optional.of(best.estimate()),
+        pairDeltas);
+  }
+
+  private LimelightEstimateCandidate chooseBestCandidate(
+      List<LimelightEstimateCandidate> candidates) {
+    return candidates.stream()
+        .min(
+            Comparator.comparingDouble(LimelightEstimateCandidate::score)
+                .thenComparing(
+                    candidate -> candidate.estimate().numTags(), Comparator.reverseOrder())
+                .thenComparing(LimelightEstimateCandidate::cameraLabel))
+        .orElseThrow();
+  }
+
+  private int computeLargestConsistentGroupSize(
+      List<LimelightEstimateCandidate> candidates, List<CameraPairDelta> pairDeltas) {
+    int n = candidates.size();
+    if (n == 0) {
+      return 0;
+    }
+    if (n == 1) {
+      return 1;
+    }
+    boolean[][] consistent = new boolean[n][n];
+    for (int i = 0; i < n; i++) {
+      consistent[i][i] = true;
+    }
+    for (CameraPairDelta pairDelta : pairDeltas) {
+      int a = pairDelta.cameraAIndex();
+      int b = pairDelta.cameraBIndex();
+      consistent[a][b] = pairDelta.consistent();
+      consistent[b][a] = pairDelta.consistent();
+    }
+
+    int best = 1;
+    int maxMask = 1 << n;
+    for (int mask = 1; mask < maxMask; mask++) {
+      int size = Integer.bitCount(mask);
+      if (size <= best) {
+        continue;
+      }
+      boolean isClique = true;
+      for (int i = 0; i < n && isClique; i++) {
+        if ((mask & (1 << i)) == 0) {
+          continue;
+        }
+        for (int j = i + 1; j < n; j++) {
+          if ((mask & (1 << j)) == 0) {
+            continue;
+          }
+          if (!consistent[i][j]) {
+            isClique = false;
+            break;
+          }
+        }
+      }
+      if (isClique) {
+        best = size;
+      }
+    }
+    return best;
+  }
+
+  private CameraPairDelta compareCandidates(
+      LimelightEstimateCandidate a,
+      LimelightEstimateCandidate b,
+      int cameraAIndex,
+      int cameraBIndex) {
+    PoseComparison comparison = comparePosesWithAlignment(a.estimate(), b.estimate());
+    boolean consistent =
+        comparison.translationDeltaMeters()
+                <= AprilTagVisionConstants.getLimelightMultiCamMaxDeltaMeters()
+            && comparison.headingDeltaDeg()
+                <= AprilTagVisionConstants.getLimelightMultiCamMaxDeltaDeg();
+    return new CameraPairDelta(
+        a.cameraLabel(),
+        b.cameraLabel(),
+        comparison.translationDeltaMeters(),
+        comparison.headingDeltaDeg(),
+        consistent,
+        cameraAIndex,
+        cameraBIndex);
+  }
+
+  private PoseComparison comparePosesWithAlignment(
+      VisionFieldPoseEstimate a, VisionFieldPoseEstimate b) {
+    if (a.timestampSeconds() <= b.timestampSeconds()) {
+      Pose2d poseAAtB =
+          alignEstimateToTimestamp(a, b.timestampSeconds()).orElse(a.visionRobotPoseMeters());
+      Pose2d poseB = b.visionRobotPoseMeters();
+      return new PoseComparison(
+          poseAAtB.getTranslation().getDistance(poseB.getTranslation()),
+          Math.abs(poseAAtB.getRotation().minus(poseB.getRotation()).getDegrees()));
+    }
+
+    Pose2d poseBAtA =
+        alignEstimateToTimestamp(b, a.timestampSeconds()).orElse(b.visionRobotPoseMeters());
+    Pose2d poseA = a.visionRobotPoseMeters();
+    return new PoseComparison(
+        poseA.getTranslation().getDistance(poseBAtA.getTranslation()),
+        Math.abs(poseA.getRotation().minus(poseBAtA.getRotation()).getDegrees()));
+  }
+
+  private Optional<Pose2d> alignEstimateToTimestamp(
+      VisionFieldPoseEstimate estimate, double timestampSeconds) {
+    if (Math.abs(estimate.timestampSeconds() - timestampSeconds) < 1e-6) {
+      return Optional.of(estimate.visionRobotPoseMeters());
+    }
+    if (poseHistory == null) {
+      return Optional.empty();
+    }
+    Optional<Pose2d> fromPose = poseHistory.getFieldToRobot(estimate.timestampSeconds());
+    Optional<Pose2d> toPose = poseHistory.getFieldToRobot(timestampSeconds);
+    if (fromPose.isEmpty() || toPose.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        estimate.visionRobotPoseMeters().transformBy(toPose.get().minus(fromPose.get())));
   }
 
   private VisionFieldPoseEstimate fuseEstimates(
       VisionFieldPoseEstimate a, VisionFieldPoseEstimate b) {
-    if (poseHistory == null) {
-      return b;
-    }
-    if (b.timestampSeconds() < a.timestampSeconds()) {
-      VisionFieldPoseEstimate tmp = a;
-      a = b;
-      b = tmp;
-    }
-
-    Optional<Pose2d> poseAAtTime = poseHistory.getFieldToRobot(a.timestampSeconds());
-    Optional<Pose2d> poseBAtTime = poseHistory.getFieldToRobot(b.timestampSeconds());
-    if (poseAAtTime.isEmpty() || poseBAtTime.isEmpty()) {
-      return b;
-    }
-
-    var a_T_b = poseBAtTime.get().minus(poseAAtTime.get());
-    Pose2d poseA = a.visionRobotPoseMeters().transformBy(a_T_b);
     Pose2d poseB = b.visionRobotPoseMeters();
+    Pose2d poseA =
+        alignEstimateToTimestamp(a, b.timestampSeconds()).orElse(a.visionRobotPoseMeters());
 
     var varianceA = a.visionMeasurementStdDevs().elementTimes(a.visionMeasurementStdDevs());
     var varianceB = b.visionMeasurementStdDevs().elementTimes(b.visionMeasurementStdDevs());
@@ -415,6 +597,60 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
     double time = b.timestampSeconds();
 
     return new VisionFieldPoseEstimate(fusedPose, time, fusedStdDev, numTags);
+  }
+
+  private void logArbitration(ArbitrationResult arbitration) {
+    Set<String> currentPairKeys = new HashSet<>();
+    Logger.recordOutput("Vision/Arbitration/CandidateCount", arbitration.candidateCount());
+    Logger.recordOutput(
+        "Vision/Arbitration/ConsistentGroupSize", arbitration.consistentGroupSize());
+    Logger.recordOutput("Vision/Arbitration/SelectedCameraName", arbitration.selectedCameraName());
+    Logger.recordOutput("Vision/Arbitration/Mode", arbitration.mode().name());
+    Logger.recordOutput("Vision/Arbitration/PairCount", arbitration.pairDeltas().size());
+    for (CameraPairDelta pair : arbitration.pairDeltas()) {
+      String key = sanitizeLogKey(pair.cameraA()) + "__" + sanitizeLogKey(pair.cameraB());
+      currentPairKeys.add(key);
+      String prefix = "Vision/Arbitration/Pairs/" + key;
+      Logger.recordOutput(prefix + "/DeltaMeters", pair.translationDeltaMeters());
+      Logger.recordOutput(prefix + "/DeltaDeg", pair.headingDeltaDeg());
+      Logger.recordOutput(prefix + "/Consistent", pair.consistent());
+    }
+    for (String staleKey : lastArbitrationPairKeys) {
+      if (currentPairKeys.contains(staleKey)) {
+        continue;
+      }
+      String prefix = "Vision/Arbitration/Pairs/" + staleKey;
+      Logger.recordOutput(prefix + "/DeltaMeters", Double.NaN);
+      Logger.recordOutput(prefix + "/DeltaDeg", Double.NaN);
+      Logger.recordOutput(prefix + "/Consistent", false);
+    }
+    lastArbitrationPairKeys.clear();
+    lastArbitrationPairKeys.addAll(currentPairKeys);
+  }
+
+  private static String sanitizeLogKey(String key) {
+    if (key == null || key.isBlank()) {
+      return "UNKNOWN";
+    }
+    return key.replace('/', '_').replace(' ', '_');
+  }
+
+  private double computeCandidateScore(
+      int tagCount,
+      double qualityUsed,
+      double avgTagArea,
+      double xStd,
+      double yStd,
+      double thetaStd) {
+    double stdComponent = xStd + yStd + (0.25 * thetaStd);
+    double qualityPenalty = 1.0 - qualityUsed;
+    double areaPenalty = 1.0 / (1.0 + Math.max(avgTagArea, 0.0));
+    double tagPenalty = 1.0 / Math.max(1, tagCount);
+    double score = stdComponent + qualityPenalty + (0.35 * areaPenalty) + tagPenalty;
+    if (!Double.isFinite(score)) {
+      return Double.MAX_VALUE;
+    }
+    return Math.max(score, 0.0);
   }
 
   private void logCameraInputs(String prefix, VisionIO.VisionIOInputs cam) {
@@ -582,6 +818,35 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
   }
 
   private record LimelightStdDevs(double x, double y, double theta, boolean finite) {}
+
+  private enum ArbitrationMode {
+    NONE,
+    SINGLE,
+    FUSED,
+    FALLBACK_SINGLE
+  }
+
+  private record LimelightEstimateCandidate(
+      String cameraLabel, VisionFieldPoseEstimate estimate, double score) {}
+
+  private record PoseComparison(double translationDeltaMeters, double headingDeltaDeg) {}
+
+  private record CameraPairDelta(
+      String cameraA,
+      String cameraB,
+      double translationDeltaMeters,
+      double headingDeltaDeg,
+      boolean consistent,
+      int cameraAIndex,
+      int cameraBIndex) {}
+
+  private record ArbitrationResult(
+      ArbitrationMode mode,
+      int candidateCount,
+      int consistentGroupSize,
+      String selectedCameraName,
+      Optional<VisionFieldPoseEstimate> estimate,
+      List<CameraPairDelta> pairDeltas) {}
 
   /** Functional interface defining a consumer that processes vision-based pose estimates. */
   @FunctionalInterface

--- a/src/test/java/org/Griffins1884/frc2026/subsystems/vision/VisionArbitrationTest.java
+++ b/src/test/java/org/Griffins1884/frc2026/subsystems/vision/VisionArbitrationTest.java
@@ -1,0 +1,344 @@
+package org.Griffins1884.frc2026.subsystems.vision;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.simulation.SimHooks;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.Griffins1884.frc2026.GlobalConstants;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class VisionArbitrationTest {
+  @BeforeAll
+  static void setup() {
+    HAL.initialize(500, 0);
+    SimHooks.pauseTiming();
+    GlobalConstants.TUNING_MODE = false;
+  }
+
+  @Test
+  void fusesWhenAllCandidatesAreConsistent() {
+    double now = Timer.getFPGATimestamp();
+    RecordingConsumer consumer = new RecordingConsumer();
+    Vision vision =
+        new Vision(
+            consumer,
+            Pose2d::new,
+            () -> 0.0,
+            new StubVisionIO(
+                "camA",
+                makeInputs(
+                    new Pose2d(2.00, 2.00, Rotation2d.fromDegrees(0.0)),
+                    now,
+                    2,
+                    1.0,
+                    0.25,
+                    0.7,
+                    0.7,
+                    4.0)),
+            new StubVisionIO(
+                "camB",
+                makeInputs(
+                    new Pose2d(2.08, 2.03, Rotation2d.fromDegrees(3.0)),
+                    now,
+                    2,
+                    1.0,
+                    0.25,
+                    0.7,
+                    0.7,
+                    4.0)));
+
+    vision.periodic();
+
+    assertEquals(1, consumer.acceptedPoses.size());
+    Pose2d fused = consumer.acceptedPoses.get(0);
+    assertTrue(fused.getX() > 2.00 && fused.getX() < 2.08);
+    assertTrue(fused.getY() > 2.00 && fused.getY() < 2.03);
+    assertTrue(fused.getRotation().getDegrees() > 0.0 && fused.getRotation().getDegrees() < 3.0);
+  }
+
+  @Test
+  void fallsBackToBestSingleWhenCandidatesConflict() {
+    double now = Timer.getFPGATimestamp();
+    RecordingConsumer consumer = new RecordingConsumer();
+    Pose2d bestPose = new Pose2d(1.20, 1.10, Rotation2d.fromDegrees(2.0));
+    Vision vision =
+        new Vision(
+            consumer,
+            Pose2d::new,
+            () -> 0.0,
+            new StubVisionIO("good", makeInputs(bestPose, now, 2, 1.0, 0.3, 0.45, 0.45, 3.0)),
+            new StubVisionIO(
+                "bad",
+                makeInputs(
+                    new Pose2d(4.0, 5.0, Rotation2d.fromDegrees(90.0)),
+                    now,
+                    1,
+                    0.35,
+                    0.02,
+                    2.5,
+                    2.5,
+                    20.0)));
+
+    vision.periodic();
+
+    assertEquals(1, consumer.acceptedPoses.size());
+    Pose2d selected = consumer.acceptedPoses.get(0);
+    assertEquals(bestPose.getX(), selected.getX(), 1e-9);
+    assertEquals(bestPose.getY(), selected.getY(), 1e-9);
+    assertEquals(bestPose.getRotation().getDegrees(), selected.getRotation().getDegrees(), 1e-9);
+  }
+
+  @Test
+  void usesSingleCandidateWhenOnlyOneExists() {
+    double now = Timer.getFPGATimestamp();
+    RecordingConsumer consumer = new RecordingConsumer();
+    Pose2d soloPose = new Pose2d(3.1, 2.2, Rotation2d.fromDegrees(-7.0));
+    Vision vision =
+        new Vision(
+            consumer,
+            Pose2d::new,
+            () -> 0.0,
+            new StubVisionIO("solo", makeInputs(soloPose, now, 2, 1.0, 0.25, 0.8, 0.8, 5.0)),
+            new StubVisionIO("empty", makeDisconnectedInputs()));
+
+    vision.periodic();
+
+    assertEquals(1, consumer.acceptedPoses.size());
+    Pose2d selected = consumer.acceptedPoses.get(0);
+    assertEquals(soloPose.getX(), selected.getX(), 1e-9);
+    assertEquals(soloPose.getY(), selected.getY(), 1e-9);
+    assertEquals(soloPose.getRotation().getDegrees(), selected.getRotation().getDegrees(), 1e-9);
+  }
+
+  @Test
+  void emitsNoMeasurementWhenNoCandidatesValid() {
+    RecordingConsumer consumer = new RecordingConsumer();
+    Vision vision =
+        new Vision(
+            consumer,
+            Pose2d::new,
+            () -> 0.0,
+            new StubVisionIO("camA", makeDisconnectedInputs()),
+            new StubVisionIO("camB", makeDisconnectedInputs()));
+
+    vision.periodic();
+
+    assertEquals(0, consumer.acceptedPoses.size());
+  }
+
+  @Test
+  void disagreementAcrossThreeCamerasStillFallsBackToSingle() {
+    double now = Timer.getFPGATimestamp();
+    RecordingConsumer consumer = new RecordingConsumer();
+    Pose2d bestPose = new Pose2d(2.00, 1.00, Rotation2d.fromDegrees(1.0));
+    Vision vision =
+        new Vision(
+            consumer,
+            Pose2d::new,
+            () -> 0.0,
+            new StubVisionIO("camA", makeInputs(bestPose, now, 2, 1.0, 0.3, 0.4, 0.4, 3.0)),
+            new StubVisionIO(
+                "camB",
+                makeInputs(
+                    new Pose2d(2.07, 1.04, Rotation2d.fromDegrees(2.5)),
+                    now,
+                    2,
+                    0.9,
+                    0.2,
+                    0.8,
+                    0.8,
+                    6.0)),
+            new StubVisionIO(
+                "camC",
+                makeInputs(
+                    new Pose2d(5.0, 1.0, Rotation2d.fromDegrees(-40.0)),
+                    now,
+                    2,
+                    0.5,
+                    0.05,
+                    1.8,
+                    1.8,
+                    12.0)));
+
+    vision.periodic();
+
+    assertEquals(1, consumer.acceptedPoses.size());
+    Pose2d selected = consumer.acceptedPoses.get(0);
+    assertEquals(bestPose.getX(), selected.getX(), 1e-9);
+    assertEquals(bestPose.getY(), selected.getY(), 1e-9);
+    assertEquals(bestPose.getRotation().getDegrees(), selected.getRotation().getDegrees(), 1e-9);
+  }
+
+  @Test
+  void fusesAtConsistencyThresholdBoundaries() {
+    double now = Timer.getFPGATimestamp();
+    double maxDeltaMeters = AprilTagVisionConstants.getLimelightMultiCamMaxDeltaMeters();
+    double maxDeltaDeg = AprilTagVisionConstants.getLimelightMultiCamMaxDeltaDeg();
+    RecordingConsumer consumer = new RecordingConsumer();
+    Vision vision =
+        new Vision(
+            consumer,
+            Pose2d::new,
+            () -> 0.0,
+            new StubVisionIO(
+                "camA",
+                makeInputs(
+                    new Pose2d(1.0, 1.0, Rotation2d.fromDegrees(0.0)),
+                    now,
+                    2,
+                    1.0,
+                    0.3,
+                    0.7,
+                    0.7,
+                    4.0)),
+            new StubVisionIO(
+                "camB",
+                makeInputs(
+                    new Pose2d(1.0 + maxDeltaMeters, 1.0, Rotation2d.fromDegrees(maxDeltaDeg)),
+                    now,
+                    2,
+                    1.0,
+                    0.3,
+                    0.7,
+                    0.7,
+                    4.0)));
+
+    vision.periodic();
+
+    assertEquals(1, consumer.acceptedPoses.size());
+    Pose2d fused = consumer.acceptedPoses.get(0);
+    assertTrue(fused.getX() > 1.0 && fused.getX() < 1.0 + maxDeltaMeters);
+    assertTrue(
+        fused.getRotation().getDegrees() > 0.0 && fused.getRotation().getDegrees() < maxDeltaDeg);
+  }
+
+  @Test
+  void usesOdometryAlignmentForCrossTimestampConsistency() {
+    RecordingConsumer consumer = new RecordingConsumer();
+    AtomicReference<Pose2d> odomPose =
+        new AtomicReference<>(new Pose2d(0.0, 0.0, new Rotation2d()));
+    StubVisionIO camA = new StubVisionIO("camA", makeDisconnectedInputs());
+    StubVisionIO camB = new StubVisionIO("camB", makeDisconnectedInputs());
+    Vision vision = new Vision(consumer, odomPose::get, () -> 0.0, camA, camB);
+
+    vision.periodic();
+    double tsOld = Timer.getFPGATimestamp();
+    SimHooks.stepTiming(0.02);
+
+    odomPose.set(new Pose2d(1.0, 0.0, new Rotation2d()));
+    vision.periodic();
+    double tsNew = Timer.getFPGATimestamp();
+    SimHooks.stepTiming(0.02);
+
+    camA.setSource(
+        makeInputs(
+            new Pose2d(2.0, 2.0, Rotation2d.fromDegrees(0.0)), tsOld, 2, 1.0, 0.3, 0.6, 0.6, 4.0));
+    camB.setSource(
+        makeInputs(
+            new Pose2d(3.0, 2.0, Rotation2d.fromDegrees(0.0)), tsNew, 2, 1.0, 0.3, 0.6, 0.6, 4.0));
+
+    vision.periodic();
+
+    assertEquals(1, consumer.acceptedPoses.size());
+    Pose2d selected = consumer.acceptedPoses.get(0);
+    assertTrue(selected.getX() > 2.5);
+  }
+
+  private static VisionIO.VisionIOInputs makeInputs(
+      Pose2d pose,
+      double timestamp,
+      int tagCount,
+      double quality,
+      double avgTagArea,
+      double mt2XStd,
+      double mt2YStd,
+      double mt2YawStdDeg) {
+    VisionIO.VisionIOInputs inputs = new VisionIO.VisionIOInputs();
+    inputs.connected = true;
+    inputs.seesTarget = true;
+    inputs.megatagCount = tagCount;
+    inputs.latestTargetObservation =
+        new VisionIO.TargetObservation(new Rotation2d(), new Rotation2d());
+    int[] tagIds = new int[tagCount];
+    for (int i = 0; i < tagCount; i++) {
+      tagIds[i] = i + 1;
+    }
+    inputs.tagIds = tagIds.clone();
+    inputs.megatagPoseEstimate =
+        new MegatagPoseEstimate(pose, timestamp, 0.0, avgTagArea, quality, tagIds);
+    inputs.standardDeviations =
+        new double[] {
+          1.2, 1.2, Math.toRadians(6.0), mt2XStd, mt2YStd, Math.toRadians(mt2YawStdDeg)
+        };
+    inputs.fiducialObservations = new FiducialObservation[tagCount];
+    for (int i = 0; i < tagCount; i++) {
+      inputs.fiducialObservations[i] = new FiducialObservation(i + 1, 0.0, 0.0, 0.1, avgTagArea);
+    }
+    return inputs;
+  }
+
+  private static VisionIO.VisionIOInputs makeDisconnectedInputs() {
+    VisionIO.VisionIOInputs inputs = new VisionIO.VisionIOInputs();
+    inputs.connected = false;
+    inputs.seesTarget = false;
+    inputs.megatagCount = 0;
+    inputs.standardDeviations = AprilTagVisionConstants.getLimelightStandardDeviations();
+    return inputs;
+  }
+
+  private static class RecordingConsumer implements Vision.VisionConsumer {
+    private final List<Pose2d> acceptedPoses = new ArrayList<>();
+
+    @Override
+    public void accept(
+        Pose2d visionRobotPoseMeters,
+        double timestampSeconds,
+        edu.wpi.first.math.Matrix<edu.wpi.first.math.numbers.N3, edu.wpi.first.math.numbers.N1>
+            visionMeasurementStdDevs) {
+      acceptedPoses.add(visionRobotPoseMeters);
+    }
+  }
+
+  private static class StubVisionIO implements VisionIO {
+    private final CameraConstants cameraConstants;
+    private VisionIOInputs source;
+
+    private StubVisionIO(String cameraName, VisionIOInputs source) {
+      this.cameraConstants =
+          new CameraConstants(cameraName, new Transform3d(), CameraType.LIMELIGHT);
+      this.source = source;
+    }
+
+    private void setSource(VisionIOInputs source) {
+      this.source = source;
+    }
+
+    @Override
+    public void updateInputs(VisionIOInputs inputs) {
+      inputs.connected = source.connected;
+      inputs.seesTarget = source.seesTarget;
+      inputs.megatagCount = source.megatagCount;
+      inputs.latestTargetObservation = source.latestTargetObservation;
+      inputs.pose3d = source.pose3d;
+      inputs.megatagPoseEstimate = source.megatagPoseEstimate;
+      inputs.fiducialObservations = source.fiducialObservations.clone();
+      inputs.standardDeviations = source.standardDeviations.clone();
+      inputs.poseObservations = source.poseObservations.clone();
+      inputs.tagIds = source.tagIds.clone();
+    }
+
+    @Override
+    public CameraConstants getCameraConstants() {
+      return cameraConstants;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement Limelight multi-camera arbitration per #57: fuse only when all candidates are mutually consistent, otherwise fall back to best single estimate
- add tunable consistency thresholds in `AprilTagVisionConstants` (`MaxDeltaMeters`, `MaxDeltaDeg`)
- add arbitration diagnostics/logging including pairwise deltas and selected mode/camera
- fix stale arbitration telemetry on gated exits (`VISION_DISABLED`, `HIGH_YAW_RATE`) and clear stale pair keys each cycle
- add off-robot unit tests for fusion, fallback, boundary thresholds, and cross-timestamp odometry alignment

## Testing
- `./gradlew spotlessCheck` ✅
- `./gradlew test --tests org.Griffins1884.frc2026.subsystems.vision.VisionArbitrationTest` ❌ (local machine missing Java 17 toolchain; only Java 21 installed)

Fixes #57
