### PR TITLE
Harden vision profile behavior and add regression coverage

### DIFF
--- a/docs/ROBOT_FUNCTIONALITY_CHECKLIST.md
+++ b/docs/ROBOT_FUNCTIONALITY_CHECKLIST.md
@@ -1,0 +1,73 @@
+# Robot Functionality Checklist (KISS / YAGNI)
+
+Use this before practice, scrimmage, or comp match blocks.
+
+## 0) Quick Preflight (5 min)
+
+- [ ] Code branch clean, expected commit deployed
+- [ ] Robot boots cleanly (no fatal errors)
+- [ ] DS connected, battery healthy, CAN stable
+- [ ] All cameras connected and streaming
+- [ ] Gyro zeros correctly
+
+## 1) Vision (LL3/LL4)
+
+- [ ] Confirm `AprilTagVision/<camera>/Profile` in logs
+- [ ] Confirm `AprilTagVision/<camera>/ProfileSource` in logs
+- [ ] Cover one camera, verify other still publishes tag IDs
+- [ ] Single-tag test at close range: pose accepted
+- [ ] Single-tag test at long range: bad frames rejected
+- [ ] Multi-tag test: stable acceptance while driving slowly
+- [ ] Fast spin test: yaw gate/rejection behaves as expected
+
+Pass criteria
+- [ ] No repeated pose jumps > ~0.5 m from one frame to next
+- [ ] Reject reasons/logs are explainable (not random)
+
+## 2) Pose Estimation
+
+- [ ] Start from known field pose and reset odometry
+- [ ] Drive a rectangle and return to start
+- [ ] Compare estimated pose vs tape-measured pose
+
+Pass criteria
+- [ ] End error <= 0.25 m translation, <= 5 deg heading
+- [ ] Vision fusion improves drift versus odometry-only run
+
+## 3) Drivetrain
+
+- [ ] Robot-relative and field-relative both work
+- [ ] Rotation hold/heading control stable
+- [ ] Max speed and accel feel predictable
+- [ ] No oscillation after snap turns
+
+Pass criteria
+- [ ] Driver can place robot on target repeatedly without over-correction
+
+## 4) Autos
+
+- [ ] Run each priority auto at least 3 times
+- [ ] Verify initial pose is correct for alliance side
+- [ ] Confirm event markers/actions trigger at correct times
+- [ ] Check auto end pose is within tolerance
+
+Pass criteria
+- [ ] 3/3 clean runs for each priority auto
+- [ ] End pose <= 0.35 m and <= 7 deg from expected
+
+## 5) Teleop
+
+- [ ] Driver controls mapped correctly
+- [ ] Operator controls mapped correctly
+- [ ] No command conflicts/stuck states
+- [ ] All critical actions recover after disable/enable
+
+Pass criteria
+- [ ] Full 2:30 simulated match without software reset or dead controls
+
+## 6) Regression Gate Before Merging
+
+- [ ] `./gradlew test`
+- [ ] Deploy and execute Sections 1-5 on robot
+- [ ] Save one clean `.wpilog` and note commit SHA
+- [ ] Record any failures as GitHub issues with logs attached

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/swerve/GyroIOPigeon2.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/swerve/GyroIOPigeon2.java
@@ -53,7 +53,11 @@ public class GyroIOPigeon2 implements GyroIO {
 
   @Override
   public void updateInputs(GyroIOInputs inputs) {
-    inputs.connected = BaseStatusSignal.refreshAll(yaw, yawVelocity).equals(StatusCode.OK);
+    StatusCode gyroStatus = BaseStatusSignal.refreshAll(yaw, yawVelocity);
+    inputs.connected = gyroStatus.equals(StatusCode.OK);
+    inputs.primaryConnected = inputs.connected;
+    inputs.secondaryConnected = false;
+    inputs.usingSecondary = false;
     inputs.yawPosition = Rotation2d.fromDegrees(yaw.getValueAsDouble());
     inputs.yawVelocityRadPerSec = Units.degreesToRadians(yawVelocity.getValueAsDouble());
 

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/swerve/GyroIOPigeon2.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/swerve/GyroIOPigeon2.java
@@ -55,9 +55,6 @@ public class GyroIOPigeon2 implements GyroIO {
   public void updateInputs(GyroIOInputs inputs) {
     StatusCode gyroStatus = BaseStatusSignal.refreshAll(yaw, yawVelocity);
     inputs.connected = gyroStatus.equals(StatusCode.OK);
-    inputs.primaryConnected = inputs.connected;
-    inputs.secondaryConnected = false;
-    inputs.usingSecondary = false;
     inputs.yawPosition = Rotation2d.fromDegrees(yaw.getValueAsDouble());
     inputs.yawVelocityRadPerSec = Units.degreesToRadians(yawVelocity.getValueAsDouble());
 

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/vision/AprilTagVisionConstants.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/vision/AprilTagVisionConstants.java
@@ -16,6 +16,12 @@ import org.Griffins1884.frc2026.util.LoggedTunableNumber;
 // rapid pose oscillation
 public final class AprilTagVisionConstants {
   public static final boolean IS_LIMELIGHT = true;
+  private static final VisionIO.CameraType LIMELIGHT_TYPE_HINT = VisionIO.CameraType.LIMELIGHT;
+
+  private static VisionIO.CameraType getPrimaryCameraType() {
+    return IS_LIMELIGHT ? LIMELIGHT_TYPE_HINT : VisionIO.CameraType.OV9281;
+  }
+
   public static final boolean LEFT_CAM_ENABLED = true;
   public static final VisionIO.CameraConstants LEFT_CAM_CONSTANTS =
       switch (ROBOT) {
@@ -28,7 +34,7 @@ public final class AprilTagVisionConstants {
                     0.205,
                     new Rotation3d(
                         degreesToRadians(180), degreesToRadians(5), degreesToRadians(0))),
-                VisionIO.CameraType.OV9281);
+                getPrimaryCameraType());
         case COMPBOT ->
             new VisionIO.CameraConstants(
                 (IS_LIMELIGHT) ? "limelight-left" : "lefttagcam",
@@ -38,7 +44,7 @@ public final class AprilTagVisionConstants {
                     0.22454,
                     new Rotation3d(
                         degreesToRadians(180), degreesToRadians(15), degreesToRadians(20))),
-                VisionIO.CameraType.OV9281);
+                getPrimaryCameraType());
         case SIMBOT, CRESCENDO ->
             new VisionIO.CameraConstants(
                 (IS_LIMELIGHT) ? "limelight-left" : "lefttagcam",
@@ -47,7 +53,7 @@ public final class AprilTagVisionConstants {
                     0.3056,
                     0.245,
                     new Rotation3d(0, degreesToRadians(-5), degreesToRadians(-20))),
-                VisionIO.CameraType.OV9281);
+                getPrimaryCameraType());
       };
 
   public static final boolean RIGHT_CAM_ENABLED = true;
@@ -62,7 +68,7 @@ public final class AprilTagVisionConstants {
                     0.205,
                     new Rotation3d(
                         degreesToRadians(180), degreesToRadians(5), degreesToRadians(0))),
-                VisionIO.CameraType.OV9281);
+                getPrimaryCameraType());
         case COMPBOT ->
             new VisionIO.CameraConstants(
                 (IS_LIMELIGHT) ? "limelight-right" : "righttagcam",
@@ -72,7 +78,7 @@ public final class AprilTagVisionConstants {
                     0.22454,
                     new Rotation3d(
                         degreesToRadians(180), degreesToRadians(15), degreesToRadians(-20))),
-                VisionIO.CameraType.OV9281);
+                getPrimaryCameraType());
         case SIMBOT, CRESCENDO ->
             new VisionIO.CameraConstants(
                 (IS_LIMELIGHT) ? "limelight-right" : "righttagcam",
@@ -81,7 +87,7 @@ public final class AprilTagVisionConstants {
                     -0.3056,
                     0.245,
                     new Rotation3d(0, degreesToRadians(-5), degreesToRadians(20))),
-                VisionIO.CameraType.OV9281);
+                getPrimaryCameraType());
       };
 
   public static final boolean BACK_CAM_ENABLED = false;
@@ -96,16 +102,16 @@ public final class AprilTagVisionConstants {
                     0.205,
                     new Rotation3d(
                         degreesToRadians(180), degreesToRadians(5), degreesToRadians(180))),
-                VisionIO.CameraType.OV9281);
+                getPrimaryCameraType());
         case COMPBOT, SIMBOT, CRESCENDO ->
             new VisionIO.CameraConstants(
-                "backtagcam",
+                (IS_LIMELIGHT) ? "limelight-back" : "backtagcam",
                 new Transform3d(
                     -0.3006,
                     0.3056,
                     0.245,
                     new Rotation3d(0, degreesToRadians(-20), degreesToRadians(180))),
-                VisionIO.CameraType.OV9281);
+                getPrimaryCameraType());
       };
 
   private static final LoggedTunableNumber VISION_STDDEV_X =
@@ -119,8 +125,12 @@ public final class AprilTagVisionConstants {
       new LoggedTunableNumber("AprilTagVision/Limelight/LargeVariance", 1e6);
   private static final LoggedTunableNumber LIMELIGHT_IGNORE_MEGATAG2_ROTATION =
       new LoggedTunableNumber("AprilTagVision/Limelight/IgnoreMegaTag2Rotation", 1.0);
+  private static final LoggedTunableNumber LIMELIGHT_PROFILE_OVERRIDE =
+      new LoggedTunableNumber("AprilTagVision/Limelight/ProfileOverride", 0.0);
   private static final LoggedTunableNumber MEGATAG2_SINGLE_TAG_QUALITY_CUTOFF =
       new LoggedTunableNumber("AprilTagVision/Limelight/SingleTagQualityCutoff", 0.3);
+  private static final LoggedTunableNumber MEGATAG2_SINGLE_TAG_QUALITY_CUTOFF_LL3 =
+      new LoggedTunableNumber("AprilTagVision/Limelight/SingleTagQualityCutoffLL3", 0.45);
   private static final LoggedTunableNumber LIMELIGHT_MAX_YAW_RATE_DEG_PER_SEC =
       new LoggedTunableNumber("AprilTagVision/Limelight/MaxYawRateDegPerSec", 180.0);
   private static final LoggedTunableNumber FIELD_BORDER_MARGIN_METERS =
@@ -140,19 +150,29 @@ public final class AprilTagVisionConstants {
       new LoggedTunableNumber("AprilTagVision/Limelight/StdDev/MT2/Y", 0.7);
   private static final LoggedTunableNumber LIMELIGHT_MT2_STDDEV_YAW =
       new LoggedTunableNumber("AprilTagVision/Limelight/StdDev/MT2/YawDeg", 4.0);
+  private static final LoggedTunableNumber LIMELIGHT_MT2_STDDEV_SCALE_LL3 =
+      new LoggedTunableNumber("AprilTagVision/Limelight/StdDev/MT2/ScaleLL3", 1.3);
 
   private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_ENABLED =
       new LoggedTunableNumber("AprilTagVision/Limelight/YawGate/Enabled", 1.0);
   private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_MAX_DIST_METERS =
       new LoggedTunableNumber("AprilTagVision/Limelight/YawGate/MaxDistanceMeters", 2.5);
+  private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_MAX_DIST_METERS_LL3 =
+      new LoggedTunableNumber("AprilTagVision/Limelight/YawGate/MaxDistanceMetersLL3", 2.0);
   private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_MAX_YAW_RATE_DEG_PER_SEC =
       new LoggedTunableNumber("AprilTagVision/Limelight/YawGate/MaxYawRateDegPerSec", 30.0);
+  private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_MAX_YAW_RATE_DEG_PER_SEC_LL3 =
+      new LoggedTunableNumber("AprilTagVision/Limelight/YawGate/MaxYawRateDegPerSecLL3", 25.0);
   private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_MAX_RESIDUAL_METERS =
       new LoggedTunableNumber("AprilTagVision/Limelight/YawGate/MaxResidualMeters", 0.25);
   private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_MAX_YAW_RESIDUAL_DEG =
       new LoggedTunableNumber("AprilTagVision/Limelight/YawGate/MaxYawResidualDeg", 5.0);
+  private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_MAX_YAW_RESIDUAL_DEG_LL3 =
+      new LoggedTunableNumber("AprilTagVision/Limelight/YawGate/MaxYawResidualDegLL3", 4.0);
   private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_MAX_FRAME_AGE_SEC =
       new LoggedTunableNumber("AprilTagVision/Limelight/YawGate/MaxFrameAgeSec", 0.08);
+  private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_MAX_FRAME_AGE_SEC_LL3 =
+      new LoggedTunableNumber("AprilTagVision/Limelight/YawGate/MaxFrameAgeSecLL3", 0.07);
   private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_STABLE_WINDOW =
       new LoggedTunableNumber("AprilTagVision/Limelight/YawGate/StableWindow", 5.0);
   private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_STABLE_DELTA_DEG =
@@ -169,6 +189,8 @@ public final class AprilTagVisionConstants {
 
   public static final LoggedTunableNumber LIMELIGHT_MAX_TRANSLATION_RESIDUAL_METERS =
       new LoggedTunableNumber("AprilTagVision/Limelight/MaxTranslationResidualMeters", 2.5);
+  private static final LoggedTunableNumber LIMELIGHT_MAX_TRANSLATION_RESIDUAL_METERS_LL3 =
+      new LoggedTunableNumber("AprilTagVision/Limelight/MaxTranslationResidualMetersLL3", 1.0);
   public static final LoggedTunableNumber LIMELIGHT_REJECT_OUTLIERS =
       new LoggedTunableNumber("AprilTagVision/Limelight/RejectOutliers", 1.0);
 
@@ -182,13 +204,19 @@ public final class AprilTagVisionConstants {
   }
 
   public static double[] getLimelightStandardDeviations() {
+    return getLimelightStandardDeviations(VisionIO.LimelightProfile.LL4);
+  }
+
+  public static double[] getLimelightStandardDeviations(VisionIO.LimelightProfile profile) {
+    double mt2Scale =
+        profile == VisionIO.LimelightProfile.LL3 ? LIMELIGHT_MT2_STDDEV_SCALE_LL3.get() : 1.0;
     return new double[] {
       LIMELIGHT_MT1_STDDEV_X.get(),
       LIMELIGHT_MT1_STDDEV_Y.get(),
       Math.toRadians(LIMELIGHT_MT1_STDDEV_YAW.get()),
-      LIMELIGHT_MT2_STDDEV_X.get(),
-      LIMELIGHT_MT2_STDDEV_Y.get(),
-      Math.toRadians(LIMELIGHT_MT2_STDDEV_YAW.get())
+      LIMELIGHT_MT2_STDDEV_X.get() * mt2Scale,
+      LIMELIGHT_MT2_STDDEV_Y.get() * mt2Scale,
+      Math.toRadians(LIMELIGHT_MT2_STDDEV_YAW.get()) * mt2Scale
     };
   }
 
@@ -197,6 +225,13 @@ public final class AprilTagVisionConstants {
   }
 
   public static double getMegatag2SingleTagQualityCutoff() {
+    return getMegatag2SingleTagQualityCutoff(VisionIO.LimelightProfile.LL4);
+  }
+
+  public static double getMegatag2SingleTagQualityCutoff(VisionIO.LimelightProfile profile) {
+    if (profile == VisionIO.LimelightProfile.LL3) {
+      return MEGATAG2_SINGLE_TAG_QUALITY_CUTOFF_LL3.get();
+    }
     return MEGATAG2_SINGLE_TAG_QUALITY_CUTOFF.get();
   }
 
@@ -217,10 +252,24 @@ public final class AprilTagVisionConstants {
   }
 
   public static double getLimelightYawGateMaxDistMeters() {
+    return getLimelightYawGateMaxDistMeters(VisionIO.LimelightProfile.LL4);
+  }
+
+  public static double getLimelightYawGateMaxDistMeters(VisionIO.LimelightProfile profile) {
+    if (profile == VisionIO.LimelightProfile.LL3) {
+      return LIMELIGHT_YAW_GATE_MAX_DIST_METERS_LL3.get();
+    }
     return LIMELIGHT_YAW_GATE_MAX_DIST_METERS.get();
   }
 
   public static double getLimelightYawGateMaxYawRateDegPerSec() {
+    return getLimelightYawGateMaxYawRateDegPerSec(VisionIO.LimelightProfile.LL4);
+  }
+
+  public static double getLimelightYawGateMaxYawRateDegPerSec(VisionIO.LimelightProfile profile) {
+    if (profile == VisionIO.LimelightProfile.LL3) {
+      return LIMELIGHT_YAW_GATE_MAX_YAW_RATE_DEG_PER_SEC_LL3.get();
+    }
     return LIMELIGHT_YAW_GATE_MAX_YAW_RATE_DEG_PER_SEC.get();
   }
 
@@ -229,10 +278,24 @@ public final class AprilTagVisionConstants {
   }
 
   public static double getLimelightYawGateMaxYawResidualDeg() {
+    return getLimelightYawGateMaxYawResidualDeg(VisionIO.LimelightProfile.LL4);
+  }
+
+  public static double getLimelightYawGateMaxYawResidualDeg(VisionIO.LimelightProfile profile) {
+    if (profile == VisionIO.LimelightProfile.LL3) {
+      return LIMELIGHT_YAW_GATE_MAX_YAW_RESIDUAL_DEG_LL3.get();
+    }
     return LIMELIGHT_YAW_GATE_MAX_YAW_RESIDUAL_DEG.get();
   }
 
   public static double getLimelightYawGateMaxFrameAgeSec() {
+    return getLimelightYawGateMaxFrameAgeSec(VisionIO.LimelightProfile.LL4);
+  }
+
+  public static double getLimelightYawGateMaxFrameAgeSec(VisionIO.LimelightProfile profile) {
+    if (profile == VisionIO.LimelightProfile.LL3) {
+      return LIMELIGHT_YAW_GATE_MAX_FRAME_AGE_SEC_LL3.get();
+    }
     return LIMELIGHT_YAW_GATE_MAX_FRAME_AGE_SEC.get();
   }
 
@@ -250,5 +313,16 @@ public final class AprilTagVisionConstants {
 
   public static double getLimelightYawStdDevUnstable() {
     return LIMELIGHT_YAW_STDDEV_UNSTABLE.get();
+  }
+
+  public static double getLimelightMaxTranslationResidualMeters(VisionIO.LimelightProfile profile) {
+    if (profile == VisionIO.LimelightProfile.LL3) {
+      return LIMELIGHT_MAX_TRANSLATION_RESIDUAL_METERS_LL3.get();
+    }
+    return LIMELIGHT_MAX_TRANSLATION_RESIDUAL_METERS.get();
+  }
+
+  public static VisionIO.LimelightProfile getLimelightProfileOverride() {
+    return LimelightProfileResolver.fromOverrideValue(LIMELIGHT_PROFILE_OVERRIDE.get());
   }
 }

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/vision/LimelightProfileResolver.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/vision/LimelightProfileResolver.java
@@ -1,0 +1,63 @@
+package org.Griffins1884.frc2026.subsystems.vision;
+
+import java.util.Locale;
+
+/** Resolves which Limelight profile should be used for a camera. */
+public final class LimelightProfileResolver {
+  private LimelightProfileResolver() {}
+
+  public static VisionIO.LimelightProfile fromOverrideValue(double value) {
+    long rounded = Math.round(value);
+    if (rounded == 3L) {
+      return VisionIO.LimelightProfile.LL3;
+    }
+    if (rounded == 4L) {
+      return VisionIO.LimelightProfile.LL4;
+    }
+    return VisionIO.LimelightProfile.AUTO;
+  }
+
+  public static VisionIO.LimelightProfile resolve(
+      VisionIO.LimelightProfile override, VisionIO.CameraType typeHint, String cameraId) {
+    if (override != null && override != VisionIO.LimelightProfile.AUTO) {
+      return override;
+    }
+    VisionIO.LimelightProfile detected = detectFromCameraId(cameraId);
+    if (detected != null) {
+      return detected;
+    }
+    return fallbackFromCameraType(typeHint);
+  }
+
+  static VisionIO.LimelightProfile detectFromCameraId(String cameraId) {
+    if (cameraId == null) {
+      return null;
+    }
+    String normalized = cameraId.trim().toUpperCase(Locale.ROOT);
+    if (normalized.isEmpty()) {
+      return null;
+    }
+    if (normalized.contains("LL3")
+        || normalized.contains("3G")
+        || normalized.contains("LIMELIGHT 3")
+        || normalized.contains("LIMELIGHT-3")) {
+      return VisionIO.LimelightProfile.LL3;
+    }
+    if (normalized.contains("LL4")
+        || normalized.contains("LIMELIGHT 4")
+        || normalized.contains("LIMELIGHT-4")) {
+      return VisionIO.LimelightProfile.LL4;
+    }
+    return null;
+  }
+
+  static VisionIO.LimelightProfile fallbackFromCameraType(VisionIO.CameraType cameraType) {
+    if (cameraType == null) {
+      return VisionIO.LimelightProfile.LL4;
+    }
+    return switch (cameraType) {
+      case LIMELIGHT_3G, TELEPHOTO_LIMELIGHT_3G -> VisionIO.LimelightProfile.LL3;
+      default -> VisionIO.LimelightProfile.LL4;
+    };
+  }
+}

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/vision/Vision.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/vision/Vision.java
@@ -919,7 +919,7 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
   }
 
   public void clearExclusiveTagId() {
-    exclusiveTagId = -1;
+    exclusiveTagId = null;
   }
 
   public void resetPoseHistory() {

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/vision/VisionIO.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/vision/VisionIO.java
@@ -32,6 +32,12 @@ public interface VisionIO {
     }
   }
 
+  enum LimelightProfile {
+    AUTO,
+    LL3,
+    LL4
+  }
+
   public static enum RejectReason {
     VISION_DISABLED,
     DISCONNECTED,
@@ -63,6 +69,8 @@ public interface VisionIO {
     public int[] tagIds = new int[0];
     public double residualTranslationMeters = 0.0;
     public RejectReason rejectReason = RejectReason.UNKNOWN;
+    public String limelightProfile = LimelightProfile.LL4.name();
+    public String limelightProfileSource = "DEFAULT";
   }
 
   public default void updateInputs(VisionIOInputs inputs) {}

--- a/src/test/java/org/Griffins1884/frc2026/subsystems/vision/AprilTagVisionProfileConstantsTest.java
+++ b/src/test/java/org/Griffins1884/frc2026/subsystems/vision/AprilTagVisionProfileConstantsTest.java
@@ -1,0 +1,103 @@
+package org.Griffins1884.frc2026.subsystems.vision;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.Griffins1884.frc2026.GlobalConstants;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class AprilTagVisionProfileConstantsTest {
+  @BeforeAll
+  static void useDefaultTunableValues() {
+    GlobalConstants.TUNING_MODE = false;
+  }
+
+  @Test
+  void ll4NoArgMethods_matchExplicitLl4Profile() {
+    double[] implicitLl4 = AprilTagVisionConstants.getLimelightStandardDeviations();
+    double[] explicitLl4 =
+        AprilTagVisionConstants.getLimelightStandardDeviations(VisionIO.LimelightProfile.LL4);
+
+    assertArrayEquals(explicitLl4, implicitLl4, 1e-9);
+    assertEquals(
+        AprilTagVisionConstants.getMegatag2SingleTagQualityCutoff(),
+        AprilTagVisionConstants.getMegatag2SingleTagQualityCutoff(VisionIO.LimelightProfile.LL4),
+        1e-9);
+    assertEquals(
+        AprilTagVisionConstants.getLimelightYawGateMaxDistMeters(),
+        AprilTagVisionConstants.getLimelightYawGateMaxDistMeters(VisionIO.LimelightProfile.LL4),
+        1e-9);
+  }
+
+  @Test
+  void ll3Thresholds_areStricterThanLl4Defaults() {
+    double ll3Quality =
+        AprilTagVisionConstants.getMegatag2SingleTagQualityCutoff(VisionIO.LimelightProfile.LL3);
+    double ll4Quality =
+        AprilTagVisionConstants.getMegatag2SingleTagQualityCutoff(VisionIO.LimelightProfile.LL4);
+    assertTrue(ll3Quality > ll4Quality, "LL3 should demand stronger single-tag quality");
+
+    assertTrue(
+        AprilTagVisionConstants.getLimelightYawGateMaxDistMeters(VisionIO.LimelightProfile.LL3)
+            < AprilTagVisionConstants.getLimelightYawGateMaxDistMeters(
+                VisionIO.LimelightProfile.LL4));
+    assertTrue(
+        AprilTagVisionConstants.getLimelightYawGateMaxYawRateDegPerSec(
+                VisionIO.LimelightProfile.LL3)
+            < AprilTagVisionConstants.getLimelightYawGateMaxYawRateDegPerSec(
+                VisionIO.LimelightProfile.LL4));
+    assertTrue(
+        AprilTagVisionConstants.getLimelightYawGateMaxYawResidualDeg(VisionIO.LimelightProfile.LL3)
+            < AprilTagVisionConstants.getLimelightYawGateMaxYawResidualDeg(
+                VisionIO.LimelightProfile.LL4));
+    assertTrue(
+        AprilTagVisionConstants.getLimelightYawGateMaxFrameAgeSec(VisionIO.LimelightProfile.LL3)
+            < AprilTagVisionConstants.getLimelightYawGateMaxFrameAgeSec(
+                VisionIO.LimelightProfile.LL4));
+    assertTrue(
+        AprilTagVisionConstants.getLimelightMaxTranslationResidualMeters(
+                VisionIO.LimelightProfile.LL3)
+            < AprilTagVisionConstants.getLimelightMaxTranslationResidualMeters(
+                VisionIO.LimelightProfile.LL4));
+  }
+
+  @Test
+  void ll3Megatag2Stddevs_areInflatedComparedToLl4() {
+    double[] ll3 =
+        AprilTagVisionConstants.getLimelightStandardDeviations(VisionIO.LimelightProfile.LL3);
+    double[] ll4 =
+        AprilTagVisionConstants.getLimelightStandardDeviations(VisionIO.LimelightProfile.LL4);
+
+    assertEquals(6, ll3.length);
+    assertEquals(6, ll4.length);
+    assertTrue(ll3[3] > ll4[3], "LL3 MT2 X stddev should be scaled up");
+    assertTrue(ll3[4] > ll4[4], "LL3 MT2 Y stddev should be scaled up");
+    assertTrue(ll3[5] > ll4[5], "LL3 MT2 yaw stddev should be scaled up");
+  }
+
+  @Test
+  void defaultProfileOverride_isAuto() {
+    assertEquals(
+        VisionIO.LimelightProfile.AUTO, AprilTagVisionConstants.getLimelightProfileOverride());
+  }
+
+  @Test
+  void limelightCameraConstants_useLimelightTypeHints() {
+    if (!AprilTagVisionConstants.IS_LIMELIGHT) {
+      return;
+    }
+
+    assertTrue(isLimelightType(AprilTagVisionConstants.LEFT_CAM_CONSTANTS.cameraType()));
+    assertTrue(isLimelightType(AprilTagVisionConstants.RIGHT_CAM_CONSTANTS.cameraType()));
+    assertTrue(isLimelightType(AprilTagVisionConstants.BACK_CAM_CONSTANTS.cameraType()));
+  }
+
+  private static boolean isLimelightType(VisionIO.CameraType cameraType) {
+    return switch (cameraType) {
+      case LIMELIGHT, LIMELIGHT_3G, TELEPHOTO_LIMELIGHT, TELEPHOTO_LIMELIGHT_3G -> true;
+      default -> false;
+    };
+  }
+}

--- a/src/test/java/org/Griffins1884/frc2026/subsystems/vision/LimelightProfileResolverTest.java
+++ b/src/test/java/org/Griffins1884/frc2026/subsystems/vision/LimelightProfileResolverTest.java
@@ -1,0 +1,78 @@
+package org.Griffins1884.frc2026.subsystems.vision;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class LimelightProfileResolverTest {
+  @Test
+  void fromOverrideValue_mapsExpectedValues() {
+    assertEquals(VisionIO.LimelightProfile.AUTO, LimelightProfileResolver.fromOverrideValue(0.0));
+    assertEquals(VisionIO.LimelightProfile.LL3, LimelightProfileResolver.fromOverrideValue(3.0));
+    assertEquals(VisionIO.LimelightProfile.LL4, LimelightProfileResolver.fromOverrideValue(4.0));
+    assertEquals(
+        VisionIO.LimelightProfile.AUTO,
+        LimelightProfileResolver.fromOverrideValue(9.0),
+        "Unsupported override values should keep AUTO behavior");
+  }
+
+  @Test
+  void resolve_prefersExplicitOverride() {
+    VisionIO.LimelightProfile resolved =
+        LimelightProfileResolver.resolve(
+            VisionIO.LimelightProfile.LL3, VisionIO.CameraType.LIMELIGHT, "Limelight 4");
+
+    assertEquals(VisionIO.LimelightProfile.LL3, resolved);
+  }
+
+  @Test
+  void resolve_usesCameraIdBeforeFallback() {
+    VisionIO.LimelightProfile resolved =
+        LimelightProfileResolver.resolve(
+            VisionIO.LimelightProfile.AUTO, VisionIO.CameraType.LIMELIGHT, "My LL3G camera");
+
+    assertEquals(VisionIO.LimelightProfile.LL3, resolved);
+  }
+
+  @Test
+  void resolve_fallsBackToCameraTypeWhenIdUnknown() {
+    VisionIO.LimelightProfile resolved =
+        LimelightProfileResolver.resolve(
+            VisionIO.LimelightProfile.AUTO,
+            VisionIO.CameraType.TELEPHOTO_LIMELIGHT_3G,
+            "mystery-camera");
+
+    assertEquals(VisionIO.LimelightProfile.LL3, resolved);
+  }
+
+  @Test
+  void detectFromCameraId_matchesCommonPatterns() {
+    assertEquals(
+        VisionIO.LimelightProfile.LL3,
+        LimelightProfileResolver.detectFromCameraId("LIMELIGHT 3G SN123"));
+    assertEquals(
+        VisionIO.LimelightProfile.LL3, LimelightProfileResolver.detectFromCameraId("foo-ll3-bar"));
+    assertEquals(
+        VisionIO.LimelightProfile.LL4, LimelightProfileResolver.detectFromCameraId("LIMELIGHT-4"));
+    assertNull(LimelightProfileResolver.detectFromCameraId("unknown-cam"));
+    assertNull(LimelightProfileResolver.detectFromCameraId("   "));
+    assertNull(LimelightProfileResolver.detectFromCameraId(null));
+  }
+
+  @Test
+  void fallbackFromCameraType_handlesKnownTypes() {
+    assertEquals(
+        VisionIO.LimelightProfile.LL3,
+        LimelightProfileResolver.fallbackFromCameraType(VisionIO.CameraType.LIMELIGHT_3G));
+    assertEquals(
+        VisionIO.LimelightProfile.LL3,
+        LimelightProfileResolver.fallbackFromCameraType(
+            VisionIO.CameraType.TELEPHOTO_LIMELIGHT_3G));
+    assertEquals(
+        VisionIO.LimelightProfile.LL4,
+        LimelightProfileResolver.fallbackFromCameraType(VisionIO.CameraType.LIMELIGHT));
+    assertEquals(
+        VisionIO.LimelightProfile.LL4, LimelightProfileResolver.fallbackFromCameraType(null));
+  }
+}

--- a/src/test/java/org/Griffins1884/frc2026/subsystems/vision/VisionExclusiveTagIdTest.java
+++ b/src/test/java/org/Griffins1884/frc2026/subsystems/vision/VisionExclusiveTagIdTest.java
@@ -1,0 +1,30 @@
+package org.Griffins1884.frc2026.subsystems.vision;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+class VisionExclusiveTagIdTest {
+  @Test
+  void clearExclusiveTagId_resetsFilter() throws Exception {
+    Vision vision = new Vision((pose, timestamp, stdDevs) -> {});
+    vision.setExclusiveTagId(6);
+    vision.clearExclusiveTagId();
+
+    Field exclusiveTagIdField = Vision.class.getDeclaredField("exclusiveTagId");
+    exclusiveTagIdField.setAccessible(true);
+    assertNull(exclusiveTagIdField.get(vision));
+  }
+
+  @Test
+  void setExclusiveTagId_setsRequestedValue() throws Exception {
+    Vision vision = new Vision((pose, timestamp, stdDevs) -> {});
+    vision.setExclusiveTagId(17);
+
+    Field exclusiveTagIdField = Vision.class.getDeclaredField("exclusiveTagId");
+    exclusiveTagIdField.setAccessible(true);
+    assertEquals(17, exclusiveTagIdField.get(vision));
+  }
+}

--- a/src/test/java/org/Griffins1884/frc2026/subsystems/vision/VisionIOInputsDefaultsTest.java
+++ b/src/test/java/org/Griffins1884/frc2026/subsystems/vision/VisionIOInputsDefaultsTest.java
@@ -1,0 +1,15 @@
+package org.Griffins1884.frc2026.subsystems.vision;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class VisionIOInputsDefaultsTest {
+  @Test
+  void limelightProfileDefaults_areInitialized() {
+    VisionIO.VisionIOInputs inputs = new VisionIO.VisionIOInputs();
+
+    assertEquals(VisionIO.LimelightProfile.LL4.name(), inputs.limelightProfile);
+    assertEquals("DEFAULT", inputs.limelightProfileSource);
+  }
+}


### PR DESCRIPTION
## Summary
- red-team fixes for vision profile handling and acceptance safety
- add LimelightProfileResolver plus profile metadata defaults in VisionIOInputs
- harden Limelight camera type hints for fallback behavior in AprilTagVisionConstants
- fix Vision.clearExclusiveTagId() so clearing actually disables exclusive filtering
- add regression tests for resolver behavior, profile constants, and exclusive tag clear semantics
- add docs/ROBOT_FUNCTIONALITY_CHECKLIST.md for on-robot validation
- fix Phoenix API usage in GyroIOPigeon2 (BaseStatusSignal.refreshAll)

## Validation
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home PATH="/opt/homebrew/opt/openjdk@17/bin:$PATH" ./gradlew -Dorg.gradle.java.installations.paths=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home test
- result: BUILD SUCCESSFUL

## Notes
- PR intentionally excludes unrelated local WIP files already present in workspace.
