### PR TITLE
Vision: harden stale/reconnect handling and alert reliability

### DIFF
--- a/src/main/java/org/Griffins1884/frc2026/subsystems/vision/AprilTagVisionConstants.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/vision/AprilTagVisionConstants.java
@@ -173,6 +173,10 @@ public final class AprilTagVisionConstants {
       new LoggedTunableNumber("AprilTagVision/Limelight/YawGate/MaxFrameAgeSec", 0.08);
   private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_MAX_FRAME_AGE_SEC_LL3 =
       new LoggedTunableNumber("AprilTagVision/Limelight/YawGate/MaxFrameAgeSecLL3", 0.07);
+  private static final LoggedTunableNumber LIMELIGHT_MAX_ACCEPTABLE_FRAME_AGE_SEC =
+      new LoggedTunableNumber("AprilTagVision/Limelight/MaxAcceptableFrameAgeSec", 0.2);
+  private static final LoggedTunableNumber LIMELIGHT_MAX_ACCEPTABLE_FRAME_AGE_SEC_LL3 =
+      new LoggedTunableNumber("AprilTagVision/Limelight/MaxAcceptableFrameAgeSecLL3", 0.18);
   private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_STABLE_WINDOW =
       new LoggedTunableNumber("AprilTagVision/Limelight/YawGate/StableWindow", 5.0);
   private static final LoggedTunableNumber LIMELIGHT_YAW_GATE_STABLE_DELTA_DEG =
@@ -297,6 +301,17 @@ public final class AprilTagVisionConstants {
       return LIMELIGHT_YAW_GATE_MAX_FRAME_AGE_SEC_LL3.get();
     }
     return LIMELIGHT_YAW_GATE_MAX_FRAME_AGE_SEC.get();
+  }
+
+  public static double getLimelightMaxAcceptableFrameAgeSec() {
+    return getLimelightMaxAcceptableFrameAgeSec(VisionIO.LimelightProfile.LL4);
+  }
+
+  public static double getLimelightMaxAcceptableFrameAgeSec(VisionIO.LimelightProfile profile) {
+    if (profile == VisionIO.LimelightProfile.LL3) {
+      return LIMELIGHT_MAX_ACCEPTABLE_FRAME_AGE_SEC_LL3.get();
+    }
+    return LIMELIGHT_MAX_ACCEPTABLE_FRAME_AGE_SEC.get();
   }
 
   public static int getLimelightYawGateStableWindow() {

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/vision/Vision.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/vision/Vision.java
@@ -31,14 +31,19 @@ import org.littletonrobotics.junction.Logger;
 
 public class Vision extends SubsystemBase implements VisionTargetProvider {
   private static final double HISTORY_WINDOW_SEC = 1.5;
+  private static final double NO_ACCEPTED_MEASUREMENT_ALERT_SEC = 1.0;
 
   private final VisionConsumer consumer;
   private final VisionIO[] io;
   private final VisionIOInputsAutoLogged[] inputs;
   private final Alert[] disconnectedAlerts;
   private final Alert[] outlierAlerts;
+  private final Alert[] noAcceptedMeasurementAlerts;
   private final Deque<YawSample>[] yawHistory;
   private final double[] lastAcceptedTimestampsSec;
+  private final double[] lastAcceptedWallClockSec;
+  private final double[] connectedSinceWallClockSec;
+  private final boolean[] wasConnected;
   private final boolean useLimelightFusion;
   private final PoseHistory poseHistory;
   @Setter private boolean useVision = true;
@@ -94,6 +99,11 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
 
     lastAcceptedTimestampsSec = new double[io.length];
     Arrays.fill(lastAcceptedTimestampsSec, Double.NEGATIVE_INFINITY);
+    lastAcceptedWallClockSec = new double[io.length];
+    Arrays.fill(lastAcceptedWallClockSec, Double.NEGATIVE_INFINITY);
+    connectedSinceWallClockSec = new double[io.length];
+    Arrays.fill(connectedSinceWallClockSec, Double.NEGATIVE_INFINITY);
+    wasConnected = new boolean[io.length];
 
     this.disconnectedAlerts = new Alert[io.length];
     for (int i = 0; i < inputs.length; i++) {
@@ -109,6 +119,15 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
               "Vision Outlier detected on camera \""
                   + io[i].getCameraConstants().cameraName()
                   + "\".",
+              Alert.AlertType.kWarning);
+    }
+    this.noAcceptedMeasurementAlerts = new Alert[io.length];
+    for (int i = 0; i < io.length; i++) {
+      noAcceptedMeasurementAlerts[i] =
+          new Alert(
+              "Vision camera \""
+                  + io[i].getCameraConstants().cameraName()
+                  + "\" is connected but has no accepted measurements.",
               Alert.AlertType.kWarning);
     }
   }
@@ -195,7 +214,10 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
     List<Pose3d> allRobotPosesAccepted = new LinkedList<>();
 
     for (int cameraIndex = 0; cameraIndex < io.length; cameraIndex++) {
-      disconnectedAlerts[cameraIndex].set(!inputs[cameraIndex].connected);
+      String cameraLabel = io[cameraIndex].getCameraConstants().cameraName();
+      boolean connected = inputs[cameraIndex].connected;
+      disconnectedAlerts[cameraIndex].set(!connected);
+      handleConnectionTransition(cameraIndex, cameraLabel, connected);
 
       List<Pose3d> tagPoses = new LinkedList<>();
       List<Pose3d> robotPoses = new LinkedList<>();
@@ -214,8 +236,16 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
         if (!isObservationValid(observation)) {
           continue;
         }
+        if (!isTimestampInOrder(cameraIndex, observation.timestamp())) {
+          String prefix = "AprilTagVision/" + cameraLabel + "/Timestamp";
+          Logger.recordOutput(prefix + "/OutOfOrder", true);
+          Logger.recordOutput(prefix + "/LastAccepted", lastAcceptedTimestampsSec[cameraIndex]);
+          Logger.recordOutput(prefix + "/Current", observation.timestamp());
+          continue;
+        }
 
         robotPosesAccepted.add(observation.pose());
+        markTimestampAccepted(cameraIndex, observation.timestamp());
 
         consumer.accept(
             observation.pose().toPose2d(),
@@ -240,6 +270,7 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
       allTagPoses.addAll(tagPoses);
       allRobotPoses.addAll(robotPoses);
       allRobotPosesAccepted.addAll(robotPosesAccepted);
+      updateNoAcceptedMeasurementAlert(cameraIndex, cameraLabel, connected, true);
     }
 
     Logger.recordOutput(
@@ -294,13 +325,7 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
     if (poseHistory != null) {
       poseHistory.update(startTime);
     }
-
-    if (startTime < ignoreVisionUntilTimestamp) {
-      Logger.recordOutput("Vision/usingVision", false);
-      Logger.recordOutput("Vision/rejectReason", "RESET_SUPPRESS");
-      Logger.recordOutput("Vision/latencyPeriodicSec", Timer.getFPGATimestamp() - startTime);
-      return;
-    }
+    boolean suppressed = startTime < ignoreVisionUntilTimestamp;
 
     double yawRateDegPerSec =
         yawRateRadPerSecSupplier != null
@@ -312,23 +337,38 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
                 <= AprilTagVisionConstants.getLimelightMaxYawRateDegPerSec();
     Logger.recordOutput("Vision/yawRateDegPerSec", yawRateDegPerSec);
     Logger.recordOutput("Vision/yawRateAccept", yawRateOk);
+    boolean visionPipelineEnabled = !suppressed && useVision && yawRateOk;
 
     List<Optional<VisionFieldPoseEstimate>> estimates = new ArrayList<>();
 
     for (int i = 0; i < io.length; i++) {
       io[i].updateInputs(inputs[i]);
       Logger.processInputs("LimelightVision/" + io[i].getCameraConstants().cameraName(), inputs[i]);
-      disconnectedAlerts[i].set(!inputs[i].connected);
+      boolean connected = inputs[i].connected;
+      disconnectedAlerts[i].set(!connected);
 
       String cameraLabel = io[i].getCameraConstants().cameraName();
+      handleConnectionTransition(i, cameraLabel, connected);
       logCameraInputs("Vision/" + cameraLabel, inputs[i]);
       logLimelightDiagnostics(cameraLabel, inputs[i]);
-      estimates.add(buildLimelightEstimate(i, cameraLabel, inputs[i]));
+      estimates.add(
+          visionPipelineEnabled
+              ? buildLimelightEstimate(i, cameraLabel, inputs[i])
+              : Optional.empty());
 
       boolean isOutlier =
           inputs[i].rejectReason == VisionIO.RejectReason.LARGE_TRANSLATION_RESIDUAL
-              || inputs[i].rejectReason == VisionIO.RejectReason.LARGE_ROTATION_RESIDUAL;
+              || inputs[i].rejectReason == VisionIO.RejectReason.LARGE_ROTATION_RESIDUAL
+              || inputs[i].rejectReason == VisionIO.RejectReason.RESIDUAL_OUTLIER;
       outlierAlerts[i].set(isOutlier);
+      updateNoAcceptedMeasurementAlert(i, cameraLabel, connected, visionPipelineEnabled);
+    }
+
+    if (suppressed) {
+      Logger.recordOutput("Vision/usingVision", false);
+      Logger.recordOutput("Vision/rejectReason", "RESET_SUPPRESS");
+      Logger.recordOutput("Vision/latencyPeriodicSec", Timer.getFPGATimestamp() - startTime);
+      return;
     }
 
     if (!useVision) {
@@ -419,6 +459,21 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
         allowYawGate ? stdDevs.theta() : AprilTagVisionConstants.getLimelightLargeVariance();
 
     double frameAgeSec = Math.max(0.0, Timer.getFPGATimestamp() - timestampSeconds);
+    double staleFrameLimitSec = AprilTagVisionConstants.getLimelightMaxAcceptableFrameAgeSec();
+    if (cameraLabel != null) {
+      String prefix = "AprilTagVision/" + cameraLabel + "/Timestamp";
+      Logger.recordOutput(prefix + "/StaleRejected", false);
+      Logger.recordOutput(prefix + "/FrameAgeSec", frameAgeSec);
+      Logger.recordOutput(prefix + "/StaleLimitSec", staleFrameLimitSec);
+    }
+    if (frameAgeSec > staleFrameLimitSec) {
+      if (cameraLabel != null) {
+        String prefix = "AprilTagVision/" + cameraLabel + "/Timestamp";
+        Logger.recordOutput(prefix + "/StaleRejected", true);
+      }
+      return Optional.empty();
+    }
+
     double gyroYawDeg =
         getReferencePose(timestampSeconds)
             .map(pose -> Math.toDegrees(pose.getRotation().getRadians()))
@@ -627,6 +682,57 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
       return;
     }
     lastAcceptedTimestampsSec[cameraIndex] = timestampSeconds;
+    lastAcceptedWallClockSec[cameraIndex] = Timer.getFPGATimestamp();
+  }
+
+  private void handleConnectionTransition(int cameraIndex, String cameraLabel, boolean connected) {
+    if (cameraIndex < 0 || cameraIndex >= wasConnected.length) {
+      return;
+    }
+
+    boolean reconnected = connected && !wasConnected[cameraIndex];
+    if (reconnected) {
+      lastAcceptedTimestampsSec[cameraIndex] = Double.NEGATIVE_INFINITY;
+      lastAcceptedWallClockSec[cameraIndex] = Double.NEGATIVE_INFINITY;
+      connectedSinceWallClockSec[cameraIndex] = Timer.getFPGATimestamp();
+      yawHistory[cameraIndex].clear();
+    } else if (!connected && wasConnected[cameraIndex]) {
+      connectedSinceWallClockSec[cameraIndex] = Double.NEGATIVE_INFINITY;
+    }
+
+    if (cameraLabel != null) {
+      Logger.recordOutput("AprilTagVision/" + cameraLabel + "/ReconnectReset", reconnected);
+    }
+
+    wasConnected[cameraIndex] = connected;
+  }
+
+  private void updateNoAcceptedMeasurementAlert(
+      int cameraIndex, String cameraLabel, boolean connected, boolean monitoringEnabled) {
+    if (cameraIndex < 0 || cameraIndex >= noAcceptedMeasurementAlerts.length) {
+      return;
+    }
+    if (!monitoringEnabled || !connected) {
+      noAcceptedMeasurementAlerts[cameraIndex].set(false);
+      if (cameraLabel != null) {
+        Logger.recordOutput("AprilTagVision/" + cameraLabel + "/NoAcceptedMeasurement", false);
+      }
+      return;
+    }
+
+    double now = Timer.getFPGATimestamp();
+    double baselineSec =
+        Math.max(connectedSinceWallClockSec[cameraIndex], lastAcceptedWallClockSec[cameraIndex]);
+    boolean noRecentAccepted =
+        isFinite(baselineSec) && (now - baselineSec) > NO_ACCEPTED_MEASUREMENT_ALERT_SEC;
+    noAcceptedMeasurementAlerts[cameraIndex].set(noRecentAccepted);
+    if (cameraLabel != null) {
+      Logger.recordOutput(
+          "AprilTagVision/" + cameraLabel + "/NoAcceptedMeasurement", noRecentAccepted);
+      Logger.recordOutput(
+          "AprilTagVision/" + cameraLabel + "/NoAcceptedMeasurementAgeSec",
+          isFinite(baselineSec) ? now - baselineSec : Double.NaN);
+    }
   }
 
   private void logCameraInputs(String prefix, VisionIO.VisionIOInputs cam) {

--- a/src/test/java/org/Griffins1884/frc2026/subsystems/vision/VisionReliabilityHardeningTest.java
+++ b/src/test/java/org/Griffins1884/frc2026/subsystems/vision/VisionReliabilityHardeningTest.java
@@ -1,0 +1,86 @@
+package org.Griffins1884.frc2026.subsystems.vision;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Transform3d;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+class VisionReliabilityHardeningTest {
+  @Test
+  void periodicLimelight_suppressedStillProcessesReconnectReset() throws Exception {
+    StubVisionIO io = new StubVisionIO("vision-test");
+    Vision vision = new Vision((pose, timestamp, stdDevs) -> {}, Pose2d::new, () -> 0.0, io);
+
+    double[] lastAccepted = (double[]) readField(vision, "lastAcceptedTimestampsSec");
+    boolean[] wasConnected = (boolean[]) readField(vision, "wasConnected");
+    lastAccepted[0] = 42.0;
+    wasConnected[0] = false;
+
+    io.connected = true;
+    vision.suppressVisionForSeconds(1.0);
+    vision.periodic();
+
+    assertEquals(Double.NEGATIVE_INFINITY, lastAccepted[0]);
+    assertTrue(wasConnected[0]);
+  }
+
+  @Test
+  void periodicLimelight_disconnectedCamera_setsRejectReason() throws Exception {
+    StubVisionIO io = new StubVisionIO("vision-test");
+    Vision vision = new Vision((pose, timestamp, stdDevs) -> {}, Pose2d::new, () -> 0.0, io);
+
+    io.connected = false;
+    vision.periodic();
+
+    Object[] visionInputs = (Object[]) readField(vision, "inputs");
+    Object input = visionInputs[0];
+    Field rejectReasonField = input.getClass().getField("rejectReason");
+    Object rejectReason = rejectReasonField.get(input);
+    assertEquals(VisionIO.RejectReason.DISCONNECTED, rejectReason);
+  }
+
+  @Test
+  void maxAcceptableFrameAge_isLooserThanYawGateFrameAge() {
+    assertTrue(
+        AprilTagVisionConstants.getLimelightMaxAcceptableFrameAgeSec()
+            > AprilTagVisionConstants.getLimelightYawGateMaxFrameAgeSec());
+    assertTrue(
+        AprilTagVisionConstants.getLimelightMaxAcceptableFrameAgeSec(VisionIO.LimelightProfile.LL3)
+            > AprilTagVisionConstants.getLimelightYawGateMaxFrameAgeSec(
+                VisionIO.LimelightProfile.LL3));
+    assertFalse(AprilTagVisionConstants.getLimelightMaxAcceptableFrameAgeSec() <= 0.0);
+  }
+
+  private static Object readField(Object target, String name) throws Exception {
+    Field field = target.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(target);
+  }
+
+  private static final class StubVisionIO implements VisionIO {
+    private final CameraConstants constants;
+    private boolean connected;
+
+    private StubVisionIO(String name) {
+      this.constants = new CameraConstants(name, new Transform3d(), CameraType.LIMELIGHT);
+    }
+
+    @Override
+    public void updateInputs(VisionIOInputs inputs) {
+      inputs.connected = connected;
+      inputs.fiducialObservations = new FiducialObservation[0];
+      inputs.tagIds = new int[0];
+      inputs.poseObservations = new PoseObservation[0];
+      inputs.megatagPoseEstimate = null;
+    }
+
+    @Override
+    public CameraConstants getCameraConstants() {
+      return constants;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- reset per-camera timestamp/yaw state on reconnect to avoid post-reconnect out-of-order lockout
- enforce timestamp ordering for Photon observations and track last accepted wallclock per camera
- process Limelight reconnect transitions even during suppression windows
- separate hard stale-frame rejection threshold from yaw-gate frame-age threshold
- include RESIDUAL_OUTLIER in outlier alerts and add gated 'connected but no accepted measurements' alert
- add focused regression tests for suppression/reconnect handling and threshold separation

## Validation
- `./gradlew --no-daemon --no-parallel -Porg.gradle.java.installations.paths=/Users/marianobelinky/.jdks/temurin-17.jdk/Contents/Home test --tests 'org.Griffins1884.frc2026.subsystems.vision.*'`
