### PR TITLE
logging: add debug/comp mode infrastructure

### DIFF
--- a/src/main/java/org/Griffins1884/frc2026/GlobalConstants.java
+++ b/src/main/java/org/Griffins1884/frc2026/GlobalConstants.java
@@ -39,10 +39,11 @@ import org.Griffins1884.frc2026.util.LoggedTunableNumber;
 public final class GlobalConstants {
   public static final RobotMode MODE = RobotMode.REAL;
   public static final RobotType ROBOT = RobotType.COMPBOT;
+  public static final LoggingMode LOGGING_MODE = resolveLoggingMode();
   public static final double ODOMETRY_FREQUENCY = 250.0;
   public static final RobotSwerveMotors robotSwerveMotors = RobotSwerveMotors.FULLKRACKENS;
 
-  public static boolean TUNING_MODE = true;
+  public static boolean TUNING_MODE = LOGGING_MODE == LoggingMode.DEBUG;
 
   public static enum RobotMode {
     /** Running on a real robot. */
@@ -64,6 +65,38 @@ public final class GlobalConstants {
     FULLSPARK,
     HALFSPARK,
     FULLKRACKENS
+  }
+
+  public static enum LoggingMode {
+    DEBUG,
+    COMP
+  }
+
+  public static boolean isDebugMode() {
+    return LOGGING_MODE == LoggingMode.DEBUG;
+  }
+
+  public static boolean isCompMode() {
+    return LOGGING_MODE == LoggingMode.COMP;
+  }
+
+  private static LoggingMode resolveLoggingMode() {
+    String override = System.getProperty("frc.logMode");
+    if (override == null || override.isBlank()) {
+      override = System.getenv("FRC_LOG_MODE");
+    }
+
+    if (override != null) {
+      String normalized = override.trim().toUpperCase();
+      if ("DEBUG".equals(normalized)) {
+        return LoggingMode.DEBUG;
+      }
+      if ("COMP".equals(normalized)) {
+        return LoggingMode.COMP;
+      }
+    }
+
+    return MODE == RobotMode.REAL ? LoggingMode.COMP : LoggingMode.DEBUG;
   }
 
   /**

--- a/src/main/java/org/Griffins1884/frc2026/Robot.java
+++ b/src/main/java/org/Griffins1884/frc2026/Robot.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import org.Griffins1884.frc2026.util.LogRollover;
+import org.Griffins1884.frc2026.util.RobotLogging;
 import org.Griffins1884.frc2026.util.RollingWPILOGWriter;
 import org.ironmaple.simulation.SimulatedArena;
 import org.littletonrobotics.junction.LogFileUtil;
@@ -60,6 +61,7 @@ public class Robot extends LoggedRobot {
     Logger.recordMetadata("GitSHA", BuildConstants.GIT_SHA);
     Logger.recordMetadata("GitDate", BuildConstants.GIT_DATE);
     Logger.recordMetadata("GitBranch", BuildConstants.GIT_BRANCH);
+    Logger.recordMetadata("LoggingMode", GlobalConstants.LOGGING_MODE.name());
     switch (BuildConstants.DIRTY) {
       case 0:
         Logger.recordMetadata("GitDirty", "All changes committed");
@@ -191,10 +193,9 @@ public class Robot extends LoggedRobot {
     characterizationCommand = robotContainer.getCharacterizationCommand();
     if (characterizationCommand != null) {
       CommandScheduler.getInstance().schedule(characterizationCommand);
-      System.out.println(
-          "Characterization command scheduled: " + characterizationCommand.getName());
+      RobotLogging.info("Characterization command scheduled: " + characterizationCommand.getName());
     } else {
-      System.out.println("Characterization chooser set to None; nothing scheduled.");
+      RobotLogging.info("Characterization chooser set to None; nothing scheduled.");
     }
   }
 
@@ -233,14 +234,16 @@ public class Robot extends LoggedRobot {
         sessionDirCreated = true;
       } catch (IOException e) {
         createAttempts++;
-        Logger.recordOutput("NTLog/DirCreateAttempts", createAttempts);
+        if (RobotLogging.isDebugMode()) {
+          Logger.recordOutput("NTLog/DirCreateAttempts", createAttempts);
+        }
         Logger.recordOutput("NTLog/SessionDirCreated", false);
-        System.err.println(
+        RobotLogging.warn(
             "[NT Log] Failed to create log directory "
                 + sessionDir
                 + ": "
                 + e.getMessage()
-                + " — retrying.");
+                + " - retrying.");
         try {
           Thread.sleep(100);
         } catch (InterruptedException interrupted) {
@@ -254,7 +257,7 @@ public class Robot extends LoggedRobot {
       if (sessionDirCreated) {
         DataLogManager.start(sessionDir.toString());
         dataLogStarted = true;
-        System.out.println("[NT Log] Writing to " + sessionDir);
+        RobotLogging.debug("[NT Log] Writing to " + sessionDir);
       }
     } catch (IllegalStateException alreadyStarted) {
       dataLogStarted = true;

--- a/src/main/java/org/Griffins1884/frc2026/util/RobotLogging.java
+++ b/src/main/java/org/Griffins1884/frc2026/util/RobotLogging.java
@@ -1,0 +1,43 @@
+package org.Griffins1884.frc2026.util;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import org.Griffins1884.frc2026.GlobalConstants;
+
+/** Shared runtime logging helpers for debug/competition behavior. */
+public final class RobotLogging {
+  private RobotLogging() {}
+
+  public static boolean isDebugMode() {
+    return GlobalConstants.isDebugMode();
+  }
+
+  public static boolean isCompMode() {
+    return GlobalConstants.isCompMode();
+  }
+
+  public static void debug(String message) {
+    if (isDebugMode()) {
+      DriverStation.reportWarning("[DEBUG] " + message, false);
+    }
+  }
+
+  public static void info(String message) {
+    DriverStation.reportWarning(message, false);
+  }
+
+  public static void warn(String message) {
+    DriverStation.reportWarning("[WARN] " + message, false);
+  }
+
+  public static void error(String message) {
+    DriverStation.reportError(message, false);
+  }
+
+  public static void error(String message, Throwable throwable) {
+    if (throwable == null) {
+      error(message);
+      return;
+    }
+    DriverStation.reportError(message + ": " + throwable.getMessage(), throwable.getStackTrace());
+  }
+}


### PR DESCRIPTION
## Summary
- add `LoggingMode` (`DEBUG`/`COMP`) selection in `GlobalConstants`
- add centralized runtime logging helper `RobotLogging`
- wire robot metadata + startup/test logging through shared helpers

## Notes
- default behavior: `REAL` => `COMP`, `SIM/REPLAY` => `DEBUG`
- optional override via `-Dfrc.logMode` or `FRC_LOG_MODE`

## Validation
- `./gradlew check`
