### PR TITLE
logging: gate verbose telemetry behind debug mode

### DIFF
--- a/src/main/java/org/Griffins1884/frc2026/commands/AutoAlignToPoseCommand.java
+++ b/src/main/java/org/Griffins1884/frc2026/commands/AutoAlignToPoseCommand.java
@@ -8,6 +8,7 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj2.command.Command;
+import org.Griffins1884.frc2026.GlobalConstants;
 import org.Griffins1884.frc2026.subsystems.swerve.SwerveSubsystem;
 import org.littletonrobotics.junction.Logger;
 
@@ -116,28 +117,36 @@ public class AutoAlignToPoseCommand extends Command {
 
     Pose2d currentPose = drive.getPose();
 
-    Logger.recordOutput("DriveToPose/currentPose", currentPose);
-    Logger.recordOutput("DriveToPose/targetLocation", target.toString());
-    Logger.recordOutput("DriveToPose/targetPose", target);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("DriveToPose/currentPose", currentPose);
+      Logger.recordOutput("DriveToPose/targetLocation", target.toString());
+      Logger.recordOutput("DriveToPose/targetPose", target);
+    }
 
     double currentDistance = currentPose.getTranslation().getDistance(target.getTranslation());
     double ffScaler =
         MathUtil.clamp((currentDistance - ffMinRadius) / (ffMaxRadius - ffMinRadius), 0.0, 1.0);
     driveErrorAbs = currentDistance;
-    Logger.recordOutput("DriveToPose/ffScaler", ffScaler);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("DriveToPose/ffScaler", ffScaler);
+    }
 
     double driveFFVelocity =
         currentDistance > gains.feedforwardGains().deadbandMeters()
             ? gains.feedforwardGains().kV() * driveController.getSetpoint().velocity
             : 0.0;
-    Logger.recordOutput("DriveToPose/DriveFFVelocity", driveFFVelocity);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("DriveToPose/DriveFFVelocity", driveFFVelocity);
+    }
 
     double driveVelocityScalar =
         driveFFVelocity * ffScaler
             + driveController.calculate(
                 driveErrorAbs, new TrapezoidProfile.State(0.0, endVelocity));
     if (currentDistance < driveController.getPositionTolerance()) driveVelocityScalar = 0.0;
-    Logger.recordOutput("DriveToPose/DrivePoseError", driveErrorAbs);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("DriveToPose/DrivePoseError", driveErrorAbs);
+    }
 
     // Calculate theta speed
     double thetaVelocity =
@@ -160,8 +169,10 @@ public class AutoAlignToPoseCommand extends Command {
             thetaVelocity,
             -AlignConstants.ALIGN_MAX_ANGULAR_SPEED.get(),
             AlignConstants.ALIGN_MAX_ANGULAR_SPEED.get());
-    Logger.recordOutput("DriveToPose/DriveVelocitySetpoint", driveVelocity);
-    Logger.recordOutput("DriveToPose/ThetaVelocitySetpointRadPerSec", thetaVelocity);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("DriveToPose/DriveVelocitySetpoint", driveVelocity);
+      Logger.recordOutput("DriveToPose/ThetaVelocitySetpointRadPerSec", thetaVelocity);
+    }
     drive.runVelocity(
         ChassisSpeeds.fromFieldRelativeSpeeds(
             driveVelocity.getX(), driveVelocity.getY(), thetaVelocity, currentPose.getRotation()));

--- a/src/main/java/org/Griffins1884/frc2026/commands/AutoAlignToPoseHolonomicCommand.java
+++ b/src/main/java/org/Griffins1884/frc2026/commands/AutoAlignToPoseHolonomicCommand.java
@@ -7,6 +7,7 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj2.command.Command;
+import org.Griffins1884.frc2026.GlobalConstants;
 import org.Griffins1884.frc2026.subsystems.swerve.SwerveSubsystem;
 import org.littletonrobotics.junction.Logger;
 
@@ -116,15 +117,19 @@ public class AutoAlignToPoseHolonomicCommand extends Command {
     Pose2d currentPose = drive.getPose();
     AlignConstants.AlignGains gains = AlignConstants.getAlignGains();
 
-    Logger.recordOutput("DriveToPoseHolonomic/currentPose", currentPose);
-    Logger.recordOutput("DriveToPoseHolonomic/targetPose", target);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("DriveToPoseHolonomic/currentPose", currentPose);
+      Logger.recordOutput("DriveToPoseHolonomic/targetPose", target);
+    }
 
     double xError = target.getX() - currentPose.getX();
     double yError = target.getY() - currentPose.getY();
     double dist = Math.hypot(xError, yError);
-    Logger.recordOutput("DriveToPoseHolonomic/xErrorMeters", xError);
-    Logger.recordOutput("DriveToPoseHolonomic/yErrorMeters", yError);
-    Logger.recordOutput("DriveToPoseHolonomic/distanceMeters", dist);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("DriveToPoseHolonomic/xErrorMeters", xError);
+      Logger.recordOutput("DriveToPoseHolonomic/yErrorMeters", yError);
+      Logger.recordOutput("DriveToPoseHolonomic/distanceMeters", dist);
+    }
 
     // Translation feedforward, scaled down near the target.
     double ffScaler = MathUtil.clamp(dist / 0.10, 0.0, 1.0);
@@ -170,9 +175,11 @@ public class AutoAlignToPoseHolonomicCommand extends Command {
             -AlignConstants.ALIGN_MAX_ANGULAR_SPEED.get(),
             AlignConstants.ALIGN_MAX_ANGULAR_SPEED.get());
 
-    Logger.recordOutput("DriveToPoseHolonomic/xVelocityMps", xVelocity);
-    Logger.recordOutput("DriveToPoseHolonomic/yVelocityMps", yVelocity);
-    Logger.recordOutput("DriveToPoseHolonomic/thetaVelocityRadPerSec", thetaVelocity);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("DriveToPoseHolonomic/xVelocityMps", xVelocity);
+      Logger.recordOutput("DriveToPoseHolonomic/yVelocityMps", yVelocity);
+      Logger.recordOutput("DriveToPoseHolonomic/thetaVelocityRadPerSec", thetaVelocity);
+    }
 
     drive.runVelocity(
         ChassisSpeeds.fromFieldRelativeSpeeds(

--- a/src/main/java/org/Griffins1884/frc2026/commands/DriveCommands.java
+++ b/src/main/java/org/Griffins1884/frc2026/commands/DriveCommands.java
@@ -39,6 +39,7 @@ import org.Griffins1884.frc2026.GlobalConstants;
 import org.Griffins1884.frc2026.subsystems.swerve.SwerveConstants;
 import org.Griffins1884.frc2026.subsystems.swerve.SwerveSubsystem;
 import org.Griffins1884.frc2026.subsystems.vision.Vision;
+import org.Griffins1884.frc2026.util.RobotLogging;
 import org.littletonrobotics.junction.Logger;
 
 public class DriveCommands {
@@ -332,9 +333,9 @@ public class DriveCommands {
                   double kV = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
 
                   NumberFormat formatter = new DecimalFormat("#0.00000");
-                  System.out.println("********** Drive FF Characterization Results **********");
-                  System.out.println("\tkS: " + formatter.format(kS));
-                  System.out.println("\tkV: " + formatter.format(kV));
+                  RobotLogging.debug("********** Drive FF Characterization Results **********");
+                  RobotLogging.debug("\tkS: " + formatter.format(kS));
+                  RobotLogging.debug("\tkV: " + formatter.format(kV));
                 }));
   }
 
@@ -393,13 +394,13 @@ public class DriveCommands {
                           (state.gyroDelta * SwerveConstants.DRIVE_BASE_RADIUS) / wheelDelta;
 
                       NumberFormat formatter = new DecimalFormat("#0.000");
-                      System.out.println(
+                      RobotLogging.debug(
                           "********** Wheel Radius Characterization Results **********");
-                      System.out.println(
+                      RobotLogging.debug(
                           "\tWheel Delta: " + formatter.format(wheelDelta) + " radians");
-                      System.out.println(
+                      RobotLogging.debug(
                           "\tGyro Delta: " + formatter.format(state.gyroDelta) + " radians");
-                      System.out.println(
+                      RobotLogging.debug(
                           "\tWheel Radius: "
                               + formatter.format(wheelRadius)
                               + " meters, "

--- a/src/main/java/org/Griffins1884/frc2026/commands/TurretCommands.java
+++ b/src/main/java/org/Griffins1884/frc2026/commands/TurretCommands.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.Griffins1884.frc2026.GlobalConstants;
 import org.Griffins1884.frc2026.subsystems.shooter.ShooterConstants;
 import org.Griffins1884.frc2026.subsystems.turret.TurretSubsystem;
 import org.Griffins1884.frc2026.util.TurretUtil;
@@ -33,16 +34,22 @@ public final class TurretCommands {
         () -> {
           Pose2d robotPose = robotPoseSupplier.get();
           Optional<Translation2d> target = targetSupplier.apply(robotPose);
-          Logger.recordOutput("Turret/AutoAim/HasTarget", target.isPresent());
+          if (GlobalConstants.isDebugMode()) {
+            Logger.recordOutput("Turret/AutoAim/HasTarget", target.isPresent());
+          }
           if (target.isEmpty()) {
             turret.setGoalRad(turret.getPositionRad());
-            Logger.recordOutput("Turret/AutoAim/GoalRad", turret.getGoalRad());
+            if (GlobalConstants.isDebugMode()) {
+              Logger.recordOutput("Turret/AutoAim/GoalRad", turret.getGoalRad());
+            }
             return;
           }
           double goalRad = TurretUtil.turretAngleToTarget(robotPose, target.get());
           turret.setGoalRad(goalRad);
-          Logger.recordOutput("Turret/AutoAim/Target", target.get());
-          Logger.recordOutput("Turret/AutoAim/GoalRad", goalRad);
+          if (GlobalConstants.isDebugMode()) {
+            Logger.recordOutput("Turret/AutoAim/Target", target.get());
+            Logger.recordOutput("Turret/AutoAim/GoalRad", goalRad);
+          }
         },
         turret);
   }
@@ -93,10 +100,12 @@ public final class TurretCommands {
     }
 
     Translation2d aimPoint = currentPose.getTranslation().plus(aimVector);
-    Logger.recordOutput("Turret/AutoAim/ShotTime", tof);
-    Logger.recordOutput("Turret/AutoAim/Distance", dist);
-    Logger.recordOutput("Turret/AutoAim/FutureTarget", aimPoint);
-    Logger.recordOutput("Turret/AutoAim/AngleToTarget", angle);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("Turret/AutoAim/ShotTime", tof);
+      Logger.recordOutput("Turret/AutoAim/Distance", dist);
+      Logger.recordOutput("Turret/AutoAim/FutureTarget", aimPoint);
+      Logger.recordOutput("Turret/AutoAim/AngleToTarget", angle);
+    }
     return aimPoint;
   }
 

--- a/src/main/java/org/Griffins1884/frc2026/generic/arms/GenericPositionArmSystem.java
+++ b/src/main/java/org/Griffins1884/frc2026/generic/arms/GenericPositionArmSystem.java
@@ -120,7 +120,11 @@ public abstract class GenericPositionArmSystem<G extends GenericPositionArmSyste
                 null,
                 null,
                 Seconds.of(4),
-                state -> Logger.recordOutput("Arms/" + name + "/SysIdState", state.toString())),
+                state -> {
+                  if (GlobalConstants.isDebugMode()) {
+                    Logger.recordOutput("Arms/" + name + "/SysIdState", state.toString());
+                  }
+                }),
             new SysIdRoutine.Mechanism(
                 voltage -> io.setVoltage(voltage.in(Volts)), sysIdLog, this));
 
@@ -139,7 +143,9 @@ public abstract class GenericPositionArmSystem<G extends GenericPositionArmSyste
   @Override
   public void periodic() {
     io.updateInputs(inputs);
-    Logger.processInputs(name, inputs);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.processInputs(name, inputs);
+    }
 
     boolean anyDisconnected = false;
     for (boolean isConnected : inputs.connected) {
@@ -203,8 +209,10 @@ public abstract class GenericPositionArmSystem<G extends GenericPositionArmSyste
     if (io.usesInternalPositionControl()) {
       double kG = config.kG() != null ? config.kG().get() : 0.0;
       io.setPositionSetpoint(goalPosition, kP, kI, kD, kG);
-      Logger.recordOutput("Arms/" + name + "/Feedforward", 0.0);
-      Logger.recordOutput("Arms/" + name + "/Goal", getGoal().toString());
+      if (GlobalConstants.isDebugMode()) {
+        Logger.recordOutput("Arms/" + name + "/Feedforward", 0.0);
+        Logger.recordOutput("Arms/" + name + "/Goal", getGoal().toString());
+      }
       return;
     }
     LoggedTunableNumber.ifChanged(
@@ -222,8 +230,10 @@ public abstract class GenericPositionArmSystem<G extends GenericPositionArmSyste
 
     io.setVoltage(outputVoltage);
 
-    Logger.recordOutput("Arms/" + name + "/Feedforward", feedforwardOutput);
-    Logger.recordOutput("Arms/" + name + "/Goal", getGoal().toString());
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("Arms/" + name + "/Feedforward", feedforwardOutput);
+      Logger.recordOutput("Arms/" + name + "/Goal", getGoal().toString());
+    }
   }
 
   public void setGoalPosition(double position) {

--- a/src/main/java/org/Griffins1884/frc2026/generic/elevators/GenericPositionElevatorSystem.java
+++ b/src/main/java/org/Griffins1884/frc2026/generic/elevators/GenericPositionElevatorSystem.java
@@ -102,8 +102,11 @@ public abstract class GenericPositionElevatorSystem<
                 null,
                 null,
                 Seconds.of(4),
-                state ->
-                    Logger.recordOutput("Elevators/" + name + "/SysIdState", state.toString())),
+                state -> {
+                  if (GlobalConstants.isDebugMode()) {
+                    Logger.recordOutput("Elevators/" + name + "/SysIdState", state.toString());
+                  }
+                }),
             new SysIdRoutine.Mechanism(
                 voltage -> io.setVoltage(voltage.in(Volts)), sysIdLog, this));
 
@@ -123,7 +126,9 @@ public abstract class GenericPositionElevatorSystem<
   @Override
   public void periodic() {
     io.updateInputs(inputs);
-    Logger.processInputs(name, inputs);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.processInputs(name, inputs);
+    }
 
     boolean anyDisconnected = false;
     for (boolean isConnected : inputs.connected) {
@@ -184,8 +189,10 @@ public abstract class GenericPositionElevatorSystem<
 
     io.setVoltage(outputVoltage);
 
-    Logger.recordOutput("Elevators/" + name + "/Feedforward", feedforwardOutput);
-    Logger.recordOutput("Elevators/" + name + "Goal", getGoal().toString());
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("Elevators/" + name + "/Feedforward", feedforwardOutput);
+      Logger.recordOutput("Elevators/" + name + "Goal", getGoal().toString());
+    }
   }
 
   public void setGoalPosition(double position) {

--- a/src/main/java/org/Griffins1884/frc2026/generic/rollers/GenericVelocityRollerSystem.java
+++ b/src/main/java/org/Griffins1884/frc2026/generic/rollers/GenericVelocityRollerSystem.java
@@ -93,7 +93,11 @@ public abstract class GenericVelocityRollerSystem<
                 null,
                 null,
                 Seconds.of(4),
-                state -> Logger.recordOutput("Rollers/" + name + "/SysIdState", state.toString())),
+                state -> {
+                  if (GlobalConstants.isDebugMode()) {
+                    Logger.recordOutput("Rollers/" + name + "/SysIdState", state.toString());
+                  }
+                }),
             new SysIdRoutine.Mechanism(voltage -> io.runVolts(voltage.in(Volts)), sysIdLog, this));
 
     disconnected = new Alert(name + " motor disconnected!", AlertType.kWarning);
@@ -111,7 +115,9 @@ public abstract class GenericVelocityRollerSystem<
   @Override
   public void periodic() {
     io.updateInputs(inputs);
-    Logger.processInputs(name, inputs);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.processInputs(name, inputs);
+    }
 
     boolean anyDisconnected = false;
     for (boolean isConnected : inputs.connected) {
@@ -183,7 +189,9 @@ public abstract class GenericVelocityRollerSystem<
 
     io.runVolts(outputVoltage);
 
-    Logger.recordOutput("Rollers/" + name + "/Feedforward", feedforwardVolts);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("Rollers/" + name + "/Feedforward", feedforwardVolts);
+    }
     Logger.recordOutput("Rollers/" + name + "Goal", getGoal().toString());
   }
 
@@ -239,17 +247,20 @@ public abstract class GenericVelocityRollerSystem<
     Logger.recordOutput("Rollers/" + name + "/Error", goalVelocity - measuredVelocity);
     Logger.recordOutput("Rollers/" + name + "/AtGoal", isAtGoal());
     Logger.recordOutput("Rollers/" + name + "/ControlMode", "EXTERNAL_PID");
-    Logger.recordOutput("Rollers/" + name + "/VelocityCommandRpm", goalVelocity);
-    Logger.recordOutput("Rollers/" + name + "/VelocityMeasuredRpm", measuredVelocity);
-    Logger.recordOutput("Rollers/" + name + "/ClosedLoopErrorRpm", goalVelocity - measuredVelocity);
-    Logger.recordOutput(
-        "Rollers/" + name + "/VelocityCommandRadPerSec", goalVelocity * RPM_TO_RAD_PER_SEC);
-    Logger.recordOutput("Rollers/" + name + "/Gains/Profile", gainsLabel);
-    Logger.recordOutput("Rollers/" + name + "/Gains/kP", activeGains.kP().get());
-    Logger.recordOutput("Rollers/" + name + "/Gains/kI", activeGains.kI().get());
-    Logger.recordOutput("Rollers/" + name + "/Gains/kD", activeGains.kD().get());
-    Logger.recordOutput("Rollers/" + name + "/Gains/kS", activeGains.kS().get());
-    Logger.recordOutput("Rollers/" + name + "/Gains/kV", activeGains.kV().get());
-    Logger.recordOutput("Rollers/" + name + "/FeedforwardDisabled", false);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("Rollers/" + name + "/VelocityCommandRpm", goalVelocity);
+      Logger.recordOutput("Rollers/" + name + "/VelocityMeasuredRpm", measuredVelocity);
+      Logger.recordOutput(
+          "Rollers/" + name + "/ClosedLoopErrorRpm", goalVelocity - measuredVelocity);
+      Logger.recordOutput(
+          "Rollers/" + name + "/VelocityCommandRadPerSec", goalVelocity * RPM_TO_RAD_PER_SEC);
+      Logger.recordOutput("Rollers/" + name + "/Gains/Profile", gainsLabel);
+      Logger.recordOutput("Rollers/" + name + "/Gains/kP", activeGains.kP().get());
+      Logger.recordOutput("Rollers/" + name + "/Gains/kI", activeGains.kI().get());
+      Logger.recordOutput("Rollers/" + name + "/Gains/kD", activeGains.kD().get());
+      Logger.recordOutput("Rollers/" + name + "/Gains/kS", activeGains.kS().get());
+      Logger.recordOutput("Rollers/" + name + "/Gains/kV", activeGains.kV().get());
+      Logger.recordOutput("Rollers/" + name + "/FeedforwardDisabled", false);
+    }
   }
 }

--- a/src/main/java/org/Griffins1884/frc2026/generic/rollers/GenericVoltageRollerSystem.java
+++ b/src/main/java/org/Griffins1884/frc2026/generic/rollers/GenericVoltageRollerSystem.java
@@ -14,6 +14,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import java.util.function.DoubleSupplier;
+import org.Griffins1884.frc2026.GlobalConstants;
 import org.littletonrobotics.junction.Logger;
 
 /**
@@ -68,7 +69,11 @@ public abstract class GenericVoltageRollerSystem<G extends GenericVoltageRollerS
                 null,
                 null,
                 Seconds.of(4),
-                state -> Logger.recordOutput("Rollers/" + name + "/SysIdState", state.toString())),
+                state -> {
+                  if (GlobalConstants.isDebugMode()) {
+                    Logger.recordOutput("Rollers/" + name + "/SysIdState", state.toString());
+                  }
+                }),
             new SysIdRoutine.Mechanism(
                 voltage -> io.runVolts(voltage.in(Volts)),
                 (log) ->
@@ -93,7 +98,9 @@ public abstract class GenericVoltageRollerSystem<G extends GenericVoltageRollerS
   @Override
   public void periodic() {
     io.updateInputs(inputs);
-    Logger.processInputs(name, inputs);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.processInputs(name, inputs);
+    }
     boolean anyDisconnected = false;
     for (boolean isConnected : inputs.connected) {
       if (!isConnected) {

--- a/src/main/java/org/Griffins1884/frc2026/generic/turrets/GenericPositionTurretSystem.java
+++ b/src/main/java/org/Griffins1884/frc2026/generic/turrets/GenericPositionTurretSystem.java
@@ -16,6 +16,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import lombok.Getter;
+import org.Griffins1884.frc2026.GlobalConstants;
 import org.Griffins1884.frc2026.util.LoggedTunableNumber;
 import org.littletonrobotics.junction.Logger;
 
@@ -80,7 +81,11 @@ public class GenericPositionTurretSystem extends SubsystemBase {
                 null,
                 null,
                 Seconds.of(4),
-                state -> Logger.recordOutput(name + "/SysIdState", state.toString())),
+                state -> {
+                  if (GlobalConstants.isDebugMode()) {
+                    Logger.recordOutput(name + "/SysIdState", state.toString());
+                  }
+                }),
             new SysIdRoutine.Mechanism(
                 voltage -> io.setVoltage(voltage.in(Volts)),
                 (log) ->
@@ -106,7 +111,9 @@ public class GenericPositionTurretSystem extends SubsystemBase {
   @Override
   public void periodic() {
     io.updateInputs(inputs);
-    Logger.processInputs(name, inputs);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.processInputs(name, inputs);
+    }
 
     if (config.useAbsoluteEncoder() && absEncoder != null) {
       double absoluteRad = getAbsoluteEncoderRad();
@@ -249,7 +256,9 @@ public class GenericPositionTurretSystem extends SubsystemBase {
     if (!absoluteSynced || Math.abs(delta) > threshold) {
       io.setPosition(absoluteRad);
       absoluteSynced = true;
-      Logger.recordOutput(name + "/AbsoluteSyncDeltaRad", delta);
+      if (GlobalConstants.isDebugMode()) {
+        Logger.recordOutput(name + "/AbsoluteSyncDeltaRad", delta);
+      }
     }
   }
 
@@ -277,16 +286,18 @@ public class GenericPositionTurretSystem extends SubsystemBase {
   private void logOutputs(double positionRad) {
     Logger.recordOutput(name + "/PositionRad", positionRad);
     Logger.recordOutput(name + "/GoalRad", goalRad);
-    Logger.recordOutput(name + "/PositionRotations", positionRad / (2.0 * Math.PI));
-    Logger.recordOutput(name + "/GoalRotations", goalRad / (2.0 * Math.PI));
     Logger.recordOutput(name + "/ErrorRad", goalRad - positionRad);
     Logger.recordOutput(name + "/AtGoal", isAtGoal());
     Logger.recordOutput(name + "/ControlMode", controlMode.toString());
     Logger.recordOutput(name + "/OpenLoopPercent", openLoopPercent);
-    Logger.recordOutput(name + "/SetpointVelocityRadPerSec", controller.getSetpoint().velocity);
-    Logger.recordOutput(name + "/MotorPositionRotations", inputs.motorPositionRotations);
-    Logger.recordOutput(name + "/MotorPositionTicks", inputs.motorPositionTicks);
-    Logger.recordOutput(name + "/MotorGoalRotations", inputs.motorGoalRotations);
-    Logger.recordOutput(name + "/MotorGoalTicks", inputs.motorGoalTicks);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput(name + "/PositionRotations", positionRad / (2.0 * Math.PI));
+      Logger.recordOutput(name + "/GoalRotations", goalRad / (2.0 * Math.PI));
+      Logger.recordOutput(name + "/SetpointVelocityRadPerSec", controller.getSetpoint().velocity);
+      Logger.recordOutput(name + "/MotorPositionRotations", inputs.motorPositionRotations);
+      Logger.recordOutput(name + "/MotorPositionTicks", inputs.motorPositionTicks);
+      Logger.recordOutput(name + "/MotorGoalRotations", inputs.motorGoalRotations);
+      Logger.recordOutput(name + "/MotorGoalTicks", inputs.motorGoalTicks);
+    }
   }
 }

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/Superstructure.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/Superstructure.java
@@ -342,7 +342,9 @@ public class Superstructure extends SubsystemBase {
         alliance.get() == DriverStation.Alliance.Red
             ? GlobalConstants.FieldConstants.fieldLength - pose.getX()
             : pose.getX();
-    Logger.recordOutput("Superstructure/AutoXBlue", xBlue);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("Superstructure/AutoXBlue", xBlue);
+    }
 
     if (xBlue < SuperstructureConstants.AUTO_STATE_SHOOTING_X_MAX_METERS) {
       return SuperState.SHOOTING;
@@ -375,7 +377,9 @@ public class Superstructure extends SubsystemBase {
       double percent = (SuperstructureConstants.MANUAL_JOG_VOLTAGE) * pivotAxis;
       arms.shooterPivot.setOpenLoop(percent);
     }
-    Logger.recordOutput("Superstructure/ManualPivotAxis", pivotAxis);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("Superstructure/ManualPivotAxis", pivotAxis);
+    }
   }
 
   private void stopManualJog() {
@@ -869,9 +873,11 @@ public class Superstructure extends SubsystemBase {
   }
 
   private void logSysIdStatus(boolean active, String name, String phase) {
-    Logger.recordOutput("Superstructure/SysId/Active", active);
-    Logger.recordOutput("Superstructure/SysId/Name", name);
-    Logger.recordOutput("Superstructure/SysId/Phase", phase);
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("Superstructure/SysId/Active", active);
+      Logger.recordOutput("Superstructure/SysId/Name", name);
+      Logger.recordOutput("Superstructure/SysId/Phase", phase);
+    }
   }
 
   private Command sysIdPhase(String name, String phase) {

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/leds/LEDSubsystem.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/leds/LEDSubsystem.java
@@ -89,7 +89,7 @@ public class LEDSubsystem extends SubsystemBase {
                   Logger.recordOutput(
                       "LED/DisabledReason",
                       realPose == null ? "DrivePoseMissing" : "AutoStartMissing");
-                  Logger.recordOutput("LED/SegmentMask", 0b0111);
+                  recordDebugOutput("LED/SegmentMask", 0b0111);
                   setPattern(LEDOutputValue.all(LEDPattern.solid(IDLE_COLOR)));
                 }
                 return;
@@ -119,11 +119,11 @@ public class LEDSubsystem extends SubsystemBase {
     double yError = robotDelta.getY();
 
     if (Math.abs(xError) <= TRANSLATION_TOLERANCE && Math.abs(yError) <= TRANSLATION_TOLERANCE) {
-      Logger.recordOutput("LED/Align/XError", xError);
-      Logger.recordOutput("LED/Align/YError", yError);
-      Logger.recordOutput("LED/Align/Aligned", true);
-      Logger.recordOutput("LED/SegmentMask", 0b0111);
-      Logger.recordOutput("LED/Pattern", "Align/Ok");
+      recordDebugOutput("LED/Align/XError", xError);
+      recordDebugOutput("LED/Align/YError", yError);
+      recordDebugOutput("LED/Align/Aligned", true);
+      recordDebugOutput("LED/SegmentMask", 0b0111);
+      recordDebugOutput("LED/Pattern", "Align/Ok");
       return LEDOutputValue.all(LEDPattern.solid(ALIGN_OK_COLOR));
     }
 
@@ -154,11 +154,11 @@ public class LEDSubsystem extends SubsystemBase {
     if (yError < -TRANSLATION_TOLERANCE) {
       segmentMask |= 0b0100;
     }
-    Logger.recordOutput("LED/Align/XError", xError);
-    Logger.recordOutput("LED/Align/YError", yError);
-    Logger.recordOutput("LED/Align/Aligned", false);
-    Logger.recordOutput("LED/SegmentMask", segmentMask);
-    Logger.recordOutput("LED/Pattern", "Align/Directional");
+    recordDebugOutput("LED/Align/XError", xError);
+    recordDebugOutput("LED/Align/YError", yError);
+    recordDebugOutput("LED/Align/Aligned", false);
+    recordDebugOutput("LED/SegmentMask", segmentMask);
+    recordDebugOutput("LED/Pattern", "Align/Directional");
 
     return new LEDOutputValue[] {
       new LEDOutputValue(left, LEFT),
@@ -169,14 +169,14 @@ public class LEDSubsystem extends SubsystemBase {
 
   private LEDOutputValue[] getTeleopPattern(SuperState state, boolean hasBall, String climbPhase) {
     if (state == null) {
-      Logger.recordOutput("LED/SegmentMask", 0b0111);
-      Logger.recordOutput("LED/Pattern", "Enabled/Unknown");
+      recordDebugOutput("LED/SegmentMask", 0b0111);
+      recordDebugOutput("LED/Pattern", "Enabled/Unknown");
       return LEDOutputValue.all(LEDPattern.solid(IDLE_COLOR));
     }
 
     if (state == SuperState.FERRYING) {
-      Logger.recordOutput("LED/SegmentMask", 0b0111);
-      Logger.recordOutput("LED/Pattern", "Enabled/Ferrying");
+      recordDebugOutput("LED/SegmentMask", 0b0111);
+      recordDebugOutput("LED/Pattern", "Enabled/Ferrying");
       return LEDOutputValue.all(LEDPattern.solid(FERRY_COLOR));
     }
 
@@ -188,14 +188,14 @@ public class LEDSubsystem extends SubsystemBase {
     Logger.recordOutput("LED/ClimbState", climbState);
     Logger.recordOutput("LED/ClimbDone", climbDone);
     if (climbState && !climbDone) {
-      Logger.recordOutput("LED/SegmentMask", 0b0111);
-      Logger.recordOutput("LED/Pattern", "Enabled/Climb");
+      recordDebugOutput("LED/SegmentMask", 0b0111);
+      recordDebugOutput("LED/Pattern", "Enabled/Climb");
       return LEDOutputValue.all(getClimbPattern(climbPhase));
     }
 
     if (state == SuperState.IDLING) {
-      Logger.recordOutput("LED/SegmentMask", 0b0111);
-      Logger.recordOutput("LED/Pattern", "Enabled/Idle");
+      recordDebugOutput("LED/SegmentMask", 0b0111);
+      recordDebugOutput("LED/Pattern", "Enabled/Idle");
       return LEDOutputValue.all(LEDPattern.solid(IDLE_COLOR));
     }
 
@@ -204,8 +204,8 @@ public class LEDSubsystem extends SubsystemBase {
       if (!HAS_BALL_SOLID) {
         pattern = pattern.breathe(BREATHE_SPEED);
       }
-      Logger.recordOutput("LED/SegmentMask", 0b0111);
-      Logger.recordOutput("LED/Pattern", "Enabled/HasBall");
+      recordDebugOutput("LED/SegmentMask", 0b0111);
+      recordDebugOutput("LED/Pattern", "Enabled/HasBall");
       return LEDOutputValue.all(pattern);
     }
 
@@ -213,8 +213,8 @@ public class LEDSubsystem extends SubsystemBase {
     if (NO_BALL_BREATHE) {
       pattern = pattern.breathe(BREATHE_SPEED);
     }
-    Logger.recordOutput("LED/SegmentMask", 0b0111);
-    Logger.recordOutput("LED/Pattern", "Enabled/NoBall");
+    recordDebugOutput("LED/SegmentMask", 0b0111);
+    recordDebugOutput("LED/Pattern", "Enabled/NoBall");
     return LEDOutputValue.all(pattern);
   }
 
@@ -250,5 +250,29 @@ public class LEDSubsystem extends SubsystemBase {
 
   public void close() {
     io.close();
+  }
+
+  private static void recordDebugOutput(String key, double value) {
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput(key, value);
+    }
+  }
+
+  private static void recordDebugOutput(String key, boolean value) {
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput(key, value);
+    }
+  }
+
+  private static void recordDebugOutput(String key, int value) {
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput(key, value);
+    }
+  }
+
+  private static void recordDebugOutput(String key, String value) {
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput(key, value);
+    }
   }
 }

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/swerve/SwerveSubsystem.java
@@ -60,6 +60,7 @@ import org.Griffins1884.frc2026.GlobalConstants;
 import org.Griffins1884.frc2026.GlobalConstants.RobotSwerveMotors;
 import org.Griffins1884.frc2026.subsystems.vision.Vision;
 import org.Griffins1884.frc2026.util.LocalADStarAK;
+import org.Griffins1884.frc2026.util.RobotLogging;
 import org.Griffins1884.frc2026.util.swerve.SwerveSetpoint;
 import org.Griffins1884.frc2026.util.swerve.SwerveSetpointGenerator;
 import org.littletonrobotics.junction.AutoLogOutput;
@@ -112,6 +113,7 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
   private String turnSysIdPhase = "IDLE";
   private boolean turnSysIdActive = false;
   private double turnSysIdLastCompleted = Double.NaN;
+  private Runnable odometryResetListener = () -> {};
 
   public SwerveSubsystem(
       GyroIO gyroIO,
@@ -192,7 +194,11 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
                 null,
                 null,
                 Seconds.of(2.5),
-                (state) -> Logger.recordOutput("Drive/SysIdState", state.toString())),
+                (state) -> {
+                  if (GlobalConstants.isDebugMode()) {
+                    Logger.recordOutput("Drive/SysIdState", state.toString());
+                  }
+                }),
             new SysIdRoutine.Mechanism(
                 (voltage) -> runDriveSysIdVoltage(voltage.in(Volts)), sysIdLogCallbackDrive, this));
 
@@ -203,7 +209,11 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
                 null,
                 null,
                 Seconds.of(2.5),
-                (state) -> Logger.recordOutput("Drive/TurnSysIdState", state.toString())),
+                (state) -> {
+                  if (GlobalConstants.isDebugMode()) {
+                    Logger.recordOutput("Drive/TurnSysIdState", state.toString());
+                  }
+                }),
             new SysIdRoutine.Mechanism(
                 (voltage) -> runTurnSysIdVoltage(voltage.in(Volts)), sysIdLogCallbackTurn, this));
   }
@@ -217,12 +227,14 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
       for (var module : modules) {
         module.periodic();
       }
-      Logger.recordOutput("Swerve/SysId/DrivePhase", driveSysIdPhase);
-      Logger.recordOutput("Swerve/SysId/DriveActive", driveSysIdActive);
-      Logger.recordOutput("Swerve/SysId/DriveLastCompleted", driveSysIdLastCompleted);
-      Logger.recordOutput("Swerve/SysId/TurnPhase", turnSysIdPhase);
-      Logger.recordOutput("Swerve/SysId/TurnActive", turnSysIdActive);
-      Logger.recordOutput("Swerve/SysId/TurnLastCompleted", turnSysIdLastCompleted);
+      if (GlobalConstants.isDebugMode()) {
+        Logger.recordOutput("Swerve/SysId/DrivePhase", driveSysIdPhase);
+        Logger.recordOutput("Swerve/SysId/DriveActive", driveSysIdActive);
+        Logger.recordOutput("Swerve/SysId/DriveLastCompleted", driveSysIdLastCompleted);
+        Logger.recordOutput("Swerve/SysId/TurnPhase", turnSysIdPhase);
+        Logger.recordOutput("Swerve/SysId/TurnActive", turnSysIdActive);
+        Logger.recordOutput("Swerve/SysId/TurnLastCompleted", turnSysIdLastCompleted);
+      }
     } finally {
       odometryLock.unlock();
     }
@@ -466,7 +478,7 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
     return Commands.sequence(
             Commands.runOnce(
                 () -> {
-                  System.out.println("[SysId] Drive Subsystem - Quasistatic (Forward) starting.");
+                  RobotLogging.debug("[SysId] Drive Subsystem - Quasistatic (Forward) starting.");
                   setDriveSysIdPhase("QS_FWD", true);
                 },
                 this),
@@ -474,7 +486,7 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
             Commands.waitSeconds(SYS_ID_IDLE_WAIT_SECONDS),
             Commands.runOnce(
                 () -> {
-                  System.out.println("[SysId] Drive Subsystem - Quasistatic (Reverse) starting.");
+                  RobotLogging.debug("[SysId] Drive Subsystem - Quasistatic (Reverse) starting.");
                   setDriveSysIdPhase("QS_REV", true);
                 },
                 this),
@@ -482,7 +494,7 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
             Commands.waitSeconds(SYS_ID_IDLE_WAIT_SECONDS),
             Commands.runOnce(
                 () -> {
-                  System.out.println("[SysId] Drive Subsystem - Dynamic (Forward) starting.");
+                  RobotLogging.debug("[SysId] Drive Subsystem - Dynamic (Forward) starting.");
                   setDriveSysIdPhase("DYN_FWD", true);
                 },
                 this),
@@ -490,7 +502,7 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
             Commands.waitSeconds(SYS_ID_IDLE_WAIT_SECONDS),
             Commands.runOnce(
                 () -> {
-                  System.out.println("[SysId] Drive Subsystem - Dynamic (Reverse) starting.");
+                  RobotLogging.debug("[SysId] Drive Subsystem - Dynamic (Reverse) starting.");
                   setDriveSysIdPhase("DYN_REV", true);
                 },
                 this),
@@ -521,7 +533,7 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
     return Commands.sequence(
             Commands.runOnce(
                 () -> {
-                  System.out.println("[SysId] Turn Subsystem - Quasistatic (Forward) starting.");
+                  RobotLogging.debug("[SysId] Turn Subsystem - Quasistatic (Forward) starting.");
                   setTurnSysIdPhase("QS_FWD", true);
                 },
                 this),
@@ -529,7 +541,7 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
             Commands.waitSeconds(SYS_ID_IDLE_WAIT_SECONDS),
             Commands.runOnce(
                 () -> {
-                  System.out.println("[SysId] Turn Subsystem - Quasistatic (Reverse) starting.");
+                  RobotLogging.debug("[SysId] Turn Subsystem - Quasistatic (Reverse) starting.");
                   setTurnSysIdPhase("QS_REV", true);
                 },
                 this),
@@ -537,7 +549,7 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
             Commands.waitSeconds(SYS_ID_IDLE_WAIT_SECONDS),
             Commands.runOnce(
                 () -> {
-                  System.out.println("[SysId] Turn Subsystem - Dynamic (Forward) starting.");
+                  RobotLogging.debug("[SysId] Turn Subsystem - Dynamic (Forward) starting.");
                   setTurnSysIdPhase("DYN_FWD", true);
                 },
                 this),
@@ -545,7 +557,7 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
             Commands.waitSeconds(SYS_ID_IDLE_WAIT_SECONDS),
             Commands.runOnce(
                 () -> {
-                  System.out.println("[SysId] Turn Subsystem - Dynamic (Reverse) starting.");
+                  RobotLogging.debug("[SysId] Turn Subsystem - Dynamic (Reverse) starting.");
                   setTurnSysIdPhase("DYN_REV", true);
                 },
                 this),
@@ -646,6 +658,11 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
     resetOdometry(pose, false);
   }
 
+  /** Registers a callback to run after any odometry reset. */
+  public void setOdometryResetListener(Runnable odometryResetListener) {
+    this.odometryResetListener = odometryResetListener != null ? odometryResetListener : () -> {};
+  }
+
   /**
    * Resets the current odometry pose and optionally aligns the gyro to the provided field heading.
    *
@@ -658,6 +675,7 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
       rawGyroRotation = pose.getRotation();
     }
     poseEstimator.resetPosition(rawGyroRotation, getModulePositions(), pose);
+    odometryResetListener.run();
   }
 
   /** Adds a new timestamped vision measurement. */
@@ -675,9 +693,7 @@ public class SwerveSubsystem extends SubsystemBase implements Vision.VisionConsu
 
     Pose2d currentPose = poseEstimator.getEstimatedPosition();
     if (!isFinitePose(currentPose)) {
-      if (!isValidRotation(rawGyroRotation)) {
-        // rawGyroRotation = visionRobotPoseMeters.getRotation();
-      }
+      rawGyroRotation = visionRobotPoseMeters.getRotation();
       poseEstimator.resetPosition(rawGyroRotation, getModulePositions(), visionRobotPoseMeters);
       return;
     }

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/vision/AprilTagVisionIOLimelight.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/vision/AprilTagVisionIOLimelight.java
@@ -14,7 +14,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.Getter;
+import org.Griffins1884.frc2026.GlobalConstants;
 import org.Griffins1884.frc2026.subsystems.swerve.SwerveSubsystem;
+import org.Griffins1884.frc2026.util.RobotLogging;
 import org.littletonrobotics.junction.Logger;
 
 /** Hardware implementation of VisionIO using Limelight cameras. */
@@ -117,32 +119,42 @@ public class AprilTagVisionIOLimelight implements VisionIO {
           inputs.fiducialObservations = fiducialObservation;
         }
         inputs.megatagCount = megatag != null ? megatag.tagCount : 0;
-        Logger.recordOutput("AprilTagVision/TagPose", robotPose3d);
+        if (GlobalConstants.isDebugMode()) {
+          Logger.recordOutput("AprilTagVision/TagPose", robotPose3d);
+        }
         String debugPrefix = "AprilTagVision/" + limelightName + "/MTCompare";
-        if (megatag1 != null) {
-          Logger.recordOutput(debugPrefix + "/MT1Pose", megatag1.pose);
-          Logger.recordOutput(debugPrefix + "/MT1YawDeg", megatag1.pose.getRotation().getDegrees());
-          Logger.recordOutput(debugPrefix + "/MT1TagCount", megatag1.tagCount);
-        }
-        if (megatag != null) {
-          Logger.recordOutput(debugPrefix + "/MT2Pose", megatag.pose);
-          Logger.recordOutput(debugPrefix + "/MT2YawDeg", megatag.pose.getRotation().getDegrees());
-          Logger.recordOutput(debugPrefix + "/MT2TagCount", megatag.tagCount);
-        }
-        if (megatag1 != null && megatag != null) {
-          Logger.recordOutput(debugPrefix + "/DeltaX", megatag.pose.getX() - megatag1.pose.getX());
-          Logger.recordOutput(debugPrefix + "/DeltaY", megatag.pose.getY() - megatag1.pose.getY());
-          Logger.recordOutput(
-              debugPrefix + "/DeltaYawDeg",
-              megatag.pose.getRotation().minus(megatag1.pose.getRotation()).getDegrees());
+        if (GlobalConstants.isDebugMode()) {
+          if (megatag1 != null) {
+            Logger.recordOutput(debugPrefix + "/MT1Pose", megatag1.pose);
+            Logger.recordOutput(
+                debugPrefix + "/MT1YawDeg", megatag1.pose.getRotation().getDegrees());
+            Logger.recordOutput(debugPrefix + "/MT1TagCount", megatag1.tagCount);
+          }
+          if (megatag != null) {
+            Logger.recordOutput(debugPrefix + "/MT2Pose", megatag.pose);
+            Logger.recordOutput(
+                debugPrefix + "/MT2YawDeg", megatag.pose.getRotation().getDegrees());
+            Logger.recordOutput(debugPrefix + "/MT2TagCount", megatag.tagCount);
+          }
+          if (megatag1 != null && megatag != null) {
+            Logger.recordOutput(
+                debugPrefix + "/DeltaX", megatag.pose.getX() - megatag1.pose.getX());
+            Logger.recordOutput(
+                debugPrefix + "/DeltaY", megatag.pose.getY() - megatag1.pose.getY());
+            Logger.recordOutput(
+                debugPrefix + "/DeltaYawDeg",
+                megatag.pose.getRotation().minus(megatag1.pose.getRotation()).getDegrees());
+          }
         }
         // Track tag IDs and pose observations for the rest of the robot code to consume.
         Set<Short> tagIds = new HashSet<>();
         List<PoseObservation> poseObservations = new ArrayList<>();
 
-        Logger.recordOutput(
-            debugPrefix + "/spinLimit",
-            Math.abs(drive.getYawRateDegreesPerSec()) <= cameraConstants.cameraType().noisySpeed);
+        if (GlobalConstants.isDebugMode()) {
+          Logger.recordOutput(
+              debugPrefix + "/spinLimit",
+              Math.abs(drive.getYawRateDegreesPerSec()) <= cameraConstants.cameraType().noisySpeed);
+        }
 
         // Only add a pose observation when we have a valid estimate and pose data.
         if (megatagPoseEstimate != null
@@ -175,7 +187,7 @@ public class AprilTagVisionIOLimelight implements VisionIO {
         inputs.poseObservations = poseObservations.toArray(new PoseObservation[0]);
         inputs.tagIds = tagIds.stream().mapToInt(Short::intValue).toArray();
       } catch (Exception e) {
-        System.err.println("Error processing Limelight data: " + e.getMessage());
+        RobotLogging.error("Error processing Limelight data", e);
       }
     }
   }

--- a/src/main/java/org/Griffins1884/frc2026/subsystems/vision/Vision.java
+++ b/src/main/java/org/Griffins1884/frc2026/subsystems/vision/Vision.java
@@ -31,14 +31,19 @@ import org.littletonrobotics.junction.Logger;
 
 public class Vision extends SubsystemBase implements VisionTargetProvider {
   private static final double HISTORY_WINDOW_SEC = 1.5;
+  private static final double NO_ACCEPTED_MEASUREMENT_ALERT_SEC = 1.0;
 
   private final VisionConsumer consumer;
   private final VisionIO[] io;
   private final VisionIOInputsAutoLogged[] inputs;
   private final Alert[] disconnectedAlerts;
   private final Alert[] outlierAlerts;
+  private final Alert[] noAcceptedMeasurementAlerts;
   private final Deque<YawSample>[] yawHistory;
   private final double[] lastAcceptedTimestampsSec;
+  private final double[] lastAcceptedWallClockSec;
+  private final double[] connectedSinceWallClockSec;
+  private final boolean[] wasConnected;
   private final boolean useLimelightFusion;
   private final PoseHistory poseHistory;
   @Setter private boolean useVision = true;
@@ -94,6 +99,11 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
 
     lastAcceptedTimestampsSec = new double[io.length];
     Arrays.fill(lastAcceptedTimestampsSec, Double.NEGATIVE_INFINITY);
+    lastAcceptedWallClockSec = new double[io.length];
+    Arrays.fill(lastAcceptedWallClockSec, Double.NEGATIVE_INFINITY);
+    connectedSinceWallClockSec = new double[io.length];
+    Arrays.fill(connectedSinceWallClockSec, Double.NEGATIVE_INFINITY);
+    wasConnected = new boolean[io.length];
 
     this.disconnectedAlerts = new Alert[io.length];
     for (int i = 0; i < inputs.length; i++) {
@@ -109,6 +119,15 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
               "Vision Outlier detected on camera \""
                   + io[i].getCameraConstants().cameraName()
                   + "\".",
+              Alert.AlertType.kWarning);
+    }
+    this.noAcceptedMeasurementAlerts = new Alert[io.length];
+    for (int i = 0; i < io.length; i++) {
+      noAcceptedMeasurementAlerts[i] =
+          new Alert(
+              "Vision camera \""
+                  + io[i].getCameraConstants().cameraName()
+                  + "\" is connected but has no accepted measurements.",
               Alert.AlertType.kWarning);
     }
   }
@@ -195,7 +214,10 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
     List<Pose3d> allRobotPosesAccepted = new LinkedList<>();
 
     for (int cameraIndex = 0; cameraIndex < io.length; cameraIndex++) {
-      disconnectedAlerts[cameraIndex].set(!inputs[cameraIndex].connected);
+      String cameraLabel = io[cameraIndex].getCameraConstants().cameraName();
+      boolean connected = inputs[cameraIndex].connected;
+      disconnectedAlerts[cameraIndex].set(!connected);
+      handleConnectionTransition(cameraIndex, cameraLabel, connected);
 
       List<Pose3d> tagPoses = new LinkedList<>();
       List<Pose3d> robotPoses = new LinkedList<>();
@@ -214,8 +236,18 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
         if (!isObservationValid(observation)) {
           continue;
         }
+        if (!isTimestampInOrder(cameraIndex, observation.timestamp())) {
+          if (GlobalConstants.isDebugMode()) {
+            String prefix = "AprilTagVision/" + cameraLabel + "/Timestamp";
+            Logger.recordOutput(prefix + "/OutOfOrder", true);
+            Logger.recordOutput(prefix + "/LastAccepted", lastAcceptedTimestampsSec[cameraIndex]);
+            Logger.recordOutput(prefix + "/Current", observation.timestamp());
+          }
+          continue;
+        }
 
         robotPosesAccepted.add(observation.pose());
+        markTimestampAccepted(cameraIndex, observation.timestamp());
 
         consumer.accept(
             observation.pose().toPose2d(),
@@ -223,33 +255,38 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
             generateDynamicStdDevs(observation, io[cameraIndex].getCameraConstants().cameraType()));
       }
 
-      Logger.recordOutput(
-          "AprilTagVision/" + io[cameraIndex].getCameraConstants().cameraName() + "/TagPoses",
-          tagPoses.toArray(new Pose3d[tagPoses.size()]));
-      Logger.recordOutput(
-          "AprilTagVision/" + io[cameraIndex].getCameraConstants().cameraName() + "/RobotPoses",
-          robotPoses.toArray(new Pose3d[robotPoses.size()]));
-      Logger.recordOutput(
-          "AprilTagVision/"
-              + io[cameraIndex].getCameraConstants().cameraName()
-              + "/RobotPosesAccepted",
-          robotPosesAccepted.toArray(new Pose3d[robotPosesAccepted.size()]));
-      Logger.recordOutput(
-          "AprilTagVision/" + io[cameraIndex].getCameraConstants().cameraName() + "/CameraPose",
-          io[cameraIndex].getCameraConstants().robotToCamera());
+      if (GlobalConstants.isDebugMode()) {
+        Logger.recordOutput(
+            "AprilTagVision/" + io[cameraIndex].getCameraConstants().cameraName() + "/TagPoses",
+            tagPoses.toArray(new Pose3d[tagPoses.size()]));
+        Logger.recordOutput(
+            "AprilTagVision/" + io[cameraIndex].getCameraConstants().cameraName() + "/RobotPoses",
+            robotPoses.toArray(new Pose3d[robotPoses.size()]));
+        Logger.recordOutput(
+            "AprilTagVision/"
+                + io[cameraIndex].getCameraConstants().cameraName()
+                + "/RobotPosesAccepted",
+            robotPosesAccepted.toArray(new Pose3d[robotPosesAccepted.size()]));
+        Logger.recordOutput(
+            "AprilTagVision/" + io[cameraIndex].getCameraConstants().cameraName() + "/CameraPose",
+            io[cameraIndex].getCameraConstants().robotToCamera());
+      }
       allTagPoses.addAll(tagPoses);
       allRobotPoses.addAll(robotPoses);
       allRobotPosesAccepted.addAll(robotPosesAccepted);
+      updateNoAcceptedMeasurementAlert(cameraIndex, cameraLabel, connected);
     }
 
-    Logger.recordOutput(
-        "AprilTagVision/Summary/TagPoses", allTagPoses.toArray(new Pose3d[allTagPoses.size()]));
-    Logger.recordOutput(
-        "AprilTagVision/Summary/RobotPoses",
-        allRobotPoses.toArray(new Pose3d[allRobotPoses.size()]));
-    Logger.recordOutput(
-        "AprilTagVision/Summary/RobotPosesAccepted",
-        allRobotPosesAccepted.toArray(new Pose3d[allRobotPosesAccepted.size()]));
+    if (GlobalConstants.isDebugMode()) {
+      Logger.recordOutput(
+          "AprilTagVision/Summary/TagPoses", allTagPoses.toArray(new Pose3d[allTagPoses.size()]));
+      Logger.recordOutput(
+          "AprilTagVision/Summary/RobotPoses",
+          allRobotPoses.toArray(new Pose3d[allRobotPoses.size()]));
+      Logger.recordOutput(
+          "AprilTagVision/Summary/RobotPosesAccepted",
+          allRobotPosesAccepted.toArray(new Pose3d[allRobotPosesAccepted.size()]));
+    }
   }
 
   private boolean isObservationValid(VisionIO.PoseObservation observation) {
@@ -318,17 +355,23 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
     for (int i = 0; i < io.length; i++) {
       io[i].updateInputs(inputs[i]);
       Logger.processInputs("LimelightVision/" + io[i].getCameraConstants().cameraName(), inputs[i]);
-      disconnectedAlerts[i].set(!inputs[i].connected);
+      boolean connected = inputs[i].connected;
+      disconnectedAlerts[i].set(!connected);
 
       String cameraLabel = io[i].getCameraConstants().cameraName();
+      handleConnectionTransition(i, cameraLabel, connected);
       logCameraInputs("Vision/" + cameraLabel, inputs[i]);
-      logLimelightDiagnostics(cameraLabel, inputs[i]);
+      if (GlobalConstants.isDebugMode()) {
+        logLimelightDiagnostics(cameraLabel, inputs[i]);
+      }
       estimates.add(buildLimelightEstimate(i, cameraLabel, inputs[i]));
 
       boolean isOutlier =
           inputs[i].rejectReason == VisionIO.RejectReason.LARGE_TRANSLATION_RESIDUAL
-              || inputs[i].rejectReason == VisionIO.RejectReason.LARGE_ROTATION_RESIDUAL;
+              || inputs[i].rejectReason == VisionIO.RejectReason.LARGE_ROTATION_RESIDUAL
+              || inputs[i].rejectReason == VisionIO.RejectReason.RESIDUAL_OUTLIER;
       outlierAlerts[i].set(isOutlier);
+      updateNoAcceptedMeasurementAlert(i, cameraLabel, connected);
     }
 
     if (!useVision) {
@@ -405,7 +448,7 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
 
     double timestampSeconds = cam.megatagPoseEstimate.timestampSeconds();
     if (!isTimestampInOrder(cameraIndex, timestampSeconds)) {
-      if (cameraLabel != null) {
+      if (cameraLabel != null && GlobalConstants.isDebugMode()) {
         String prefix = "AprilTagVision/" + cameraLabel + "/Timestamp";
         Logger.recordOutput(prefix + "/OutOfOrder", true);
         Logger.recordOutput(prefix + "/LastAccepted", lastAcceptedTimestampsSec[cameraIndex]);
@@ -419,6 +462,21 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
         allowYawGate ? stdDevs.theta() : AprilTagVisionConstants.getLimelightLargeVariance();
 
     double frameAgeSec = Math.max(0.0, Timer.getFPGATimestamp() - timestampSeconds);
+    double staleFrameLimitSec = AprilTagVisionConstants.getLimelightYawGateMaxFrameAgeSec();
+    if (cameraLabel != null && GlobalConstants.isDebugMode()) {
+      String prefix = "AprilTagVision/" + cameraLabel + "/Timestamp";
+      Logger.recordOutput(prefix + "/StaleRejected", false);
+      Logger.recordOutput(prefix + "/FrameAgeSec", frameAgeSec);
+      Logger.recordOutput(prefix + "/StaleLimitSec", staleFrameLimitSec);
+    }
+    if (frameAgeSec > staleFrameLimitSec) {
+      if (cameraLabel != null && GlobalConstants.isDebugMode()) {
+        String prefix = "AprilTagVision/" + cameraLabel + "/Timestamp";
+        Logger.recordOutput(prefix + "/StaleRejected", true);
+      }
+      return Optional.empty();
+    }
+
     double gyroYawDeg =
         getReferencePose(timestampSeconds)
             .map(pose -> Math.toDegrees(pose.getRotation().getRadians()))
@@ -447,7 +505,7 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
         thetaStd = AprilTagVisionConstants.getLimelightYawStdDevUnstable();
       }
     }
-    if (cameraLabel != null) {
+    if (cameraLabel != null && GlobalConstants.isDebugMode()) {
       String prefix = "AprilTagVision/" + cameraLabel + "/YawGate";
       Logger.recordOutput(prefix + "/Pass", yawGate);
       Logger.recordOutput(prefix + "/ResidualDeg", yawGateResult.residualDeg());
@@ -627,6 +685,53 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
       return;
     }
     lastAcceptedTimestampsSec[cameraIndex] = timestampSeconds;
+    lastAcceptedWallClockSec[cameraIndex] = Timer.getFPGATimestamp();
+  }
+
+  private void handleConnectionTransition(int cameraIndex, String cameraLabel, boolean connected) {
+    if (cameraIndex < 0 || cameraIndex >= wasConnected.length) {
+      return;
+    }
+
+    boolean reconnected = connected && !wasConnected[cameraIndex];
+    if (reconnected) {
+      lastAcceptedTimestampsSec[cameraIndex] = Double.NEGATIVE_INFINITY;
+      lastAcceptedWallClockSec[cameraIndex] = Double.NEGATIVE_INFINITY;
+      connectedSinceWallClockSec[cameraIndex] = Timer.getFPGATimestamp();
+      yawHistory[cameraIndex].clear();
+    } else if (!connected && wasConnected[cameraIndex]) {
+      connectedSinceWallClockSec[cameraIndex] = Double.NEGATIVE_INFINITY;
+    }
+
+    if (cameraLabel != null && GlobalConstants.isDebugMode()) {
+      Logger.recordOutput("AprilTagVision/" + cameraLabel + "/ReconnectReset", reconnected);
+    }
+
+    wasConnected[cameraIndex] = connected;
+  }
+
+  private void updateNoAcceptedMeasurementAlert(
+      int cameraIndex, String cameraLabel, boolean connected) {
+    if (cameraIndex < 0 || cameraIndex >= noAcceptedMeasurementAlerts.length) {
+      return;
+    }
+    double now = Timer.getFPGATimestamp();
+    double baselineSec =
+        Math.max(connectedSinceWallClockSec[cameraIndex], lastAcceptedWallClockSec[cameraIndex]);
+    boolean noRecentAccepted =
+        connected
+            && isFinite(baselineSec)
+            && (now - baselineSec) > NO_ACCEPTED_MEASUREMENT_ALERT_SEC;
+    noAcceptedMeasurementAlerts[cameraIndex].set(noRecentAccepted);
+    if (cameraLabel != null) {
+      Logger.recordOutput(
+          "AprilTagVision/" + cameraLabel + "/NoAcceptedMeasurement", noRecentAccepted);
+      if (GlobalConstants.isDebugMode()) {
+        Logger.recordOutput(
+            "AprilTagVision/" + cameraLabel + "/NoAcceptedMeasurementAgeSec",
+            isFinite(baselineSec) ? now - baselineSec : Double.NaN);
+      }
+    }
   }
 
   private void logCameraInputs(String prefix, VisionIO.VisionIOInputs cam) {
@@ -639,17 +744,24 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
     }
 
     if (cam.pose3d != null) {
-      Logger.recordOutput(prefix + "/Pose3d", cam.pose3d);
+      if (GlobalConstants.isDebugMode()) {
+        Logger.recordOutput(prefix + "/Pose3d", cam.pose3d);
+      }
     }
 
     if (cam.megatagPoseEstimate != null) {
-      Logger.recordOutput(prefix + "/MegatagPoseEstimate", cam.megatagPoseEstimate.fieldToRobot());
-      Logger.recordOutput(prefix + "/Quality", cam.megatagPoseEstimate.quality());
-      Logger.recordOutput(prefix + "/AvgTagArea", cam.megatagPoseEstimate.avgTagArea());
+      if (GlobalConstants.isDebugMode()) {
+        Logger.recordOutput(
+            prefix + "/MegatagPoseEstimate", cam.megatagPoseEstimate.fieldToRobot());
+        Logger.recordOutput(prefix + "/Quality", cam.megatagPoseEstimate.quality());
+        Logger.recordOutput(prefix + "/AvgTagArea", cam.megatagPoseEstimate.avgTagArea());
+      }
     }
 
     if (cam.fiducialObservations != null) {
-      Logger.recordOutput(prefix + "/FiducialCount", cam.fiducialObservations.length);
+      if (GlobalConstants.isDebugMode()) {
+        Logger.recordOutput(prefix + "/FiducialCount", cam.fiducialObservations.length);
+      }
     }
   }
 
@@ -689,6 +801,9 @@ public class Vision extends SubsystemBase implements VisionTargetProvider {
   }
 
   private void logLimelightDiagnostics(String cameraLabel, VisionIO.VisionIOInputs cam) {
+    if (!GlobalConstants.isDebugMode()) {
+      return;
+    }
     String prefix = "AprilTagVision/" + cameraLabel + "/LimelightDiagnostics";
     boolean connected = cam.connected;
     boolean seesTarget = cam.seesTarget;

--- a/src/main/java/org/Griffins1884/frc2026/util/AutoStartPoseProvider.java
+++ b/src/main/java/org/Griffins1884/frc2026/util/AutoStartPoseProvider.java
@@ -51,36 +51,36 @@ public class AutoStartPoseProvider {
   private Optional<Pose2d> loadStartPose(String autoName) {
     Path autoPath = autoDir.resolve(autoName + ".auto");
     if (!Files.exists(autoPath)) {
-      Logger.recordOutput("AutoStartPose/AutoFileExists", false);
+      logDebugOutput("AutoStartPose/AutoFileExists", false);
       Logger.recordOutput("AutoStartPose/Reason", "MissingAutoFile");
       return Optional.empty();
     }
-    Logger.recordOutput("AutoStartPose/AutoFileExists", true);
+    logDebugOutput("AutoStartPose/AutoFileExists", true);
     JSONObject root = readJson(autoPath);
     if (root == null) {
       Logger.recordOutput("AutoStartPose/Reason", "AutoParseFailed");
       return Optional.empty();
     }
     boolean choreoAuto = Boolean.TRUE.equals(root.get("choreoAuto"));
-    Logger.recordOutput("AutoStartPose/IsChoreoAuto", choreoAuto);
+    logDebugOutput("AutoStartPose/IsChoreoAuto", choreoAuto);
     JSONObject command = asObject(root.get("command"));
     String pathName = findFirstPathName(command);
     if (pathName == null || pathName.isBlank()) {
       Logger.recordOutput("AutoStartPose/Reason", "NoPathInAuto");
       return Optional.empty();
     }
-    Logger.recordOutput("AutoStartPose/PathName", pathName);
+    logDebugOutput("AutoStartPose/PathName", pathName);
     return choreoAuto ? loadChoreoStartPose(pathName) : loadPathPlannerStartPose(pathName);
   }
 
   private Optional<Pose2d> loadChoreoStartPose(String pathName) {
     Path trajPath = choreoDir.resolve(pathName + ".traj");
     if (!Files.exists(trajPath)) {
-      Logger.recordOutput("AutoStartPose/TrajFileExists", false);
+      logDebugOutput("AutoStartPose/TrajFileExists", false);
       Logger.recordOutput("AutoStartPose/Reason", "MissingTrajFile");
       return Optional.empty();
     }
-    Logger.recordOutput("AutoStartPose/TrajFileExists", true);
+    logDebugOutput("AutoStartPose/TrajFileExists", true);
     JSONObject root = readJson(trajPath);
     if (root == null) {
       Logger.recordOutput("AutoStartPose/Reason", "TrajParseFailed");
@@ -122,11 +122,11 @@ public class AutoStartPoseProvider {
   private Optional<Pose2d> loadPathPlannerStartPose(String pathName) {
     Path pathPath = pathDir.resolve(pathName + ".path");
     if (!Files.exists(pathPath)) {
-      Logger.recordOutput("AutoStartPose/PathFileExists", false);
+      logDebugOutput("AutoStartPose/PathFileExists", false);
       Logger.recordOutput("AutoStartPose/Reason", "MissingPathFile");
       return Optional.empty();
     }
-    Logger.recordOutput("AutoStartPose/PathFileExists", true);
+    logDebugOutput("AutoStartPose/PathFileExists", true);
     JSONObject root = readJson(pathPath);
     if (root == null) {
       Logger.recordOutput("AutoStartPose/Reason", "PathParseFailed");
@@ -211,5 +211,17 @@ public class AutoStartPoseProvider {
       }
     }
     return fallback;
+  }
+
+  private static void logDebugOutput(String key, boolean value) {
+    if (RobotLogging.isDebugMode()) {
+      Logger.recordOutput(key, value);
+    }
+  }
+
+  private static void logDebugOutput(String key, String value) {
+    if (RobotLogging.isDebugMode()) {
+      Logger.recordOutput(key, value);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- gate high-volume debug telemetry behind `GlobalConstants.isDebugMode()`
- keep competition-critical outputs (state/goal/error/diagnostic essentials) always on
- apply to vision, swerve sysid traces, LEDs, superstructure debug paths, generic mechanisms, align/turret command traces

## Validation
- `./gradlew check`
