### PR TITLE
[Demo] Add Java runtime profile coverage through agentic harness

### DIFF
--- a/src/test/java/org/Griffins1884/frc2026/runtime/RuntimeProfileCodecTest.java
+++ b/src/test/java/org/Griffins1884/frc2026/runtime/RuntimeProfileCodecTest.java
@@ -1,0 +1,72 @@
+package org.Griffins1884.frc2026.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.EnumSet;
+import java.util.Set;
+import org.Griffins1884.frc2026.GlobalConstants;
+import org.Griffins1884.frc2026.mechanisms.MechanismTelemetry;
+import org.junit.jupiter.api.Test;
+
+class RuntimeProfileCodecTest {
+  @Test
+  void fromJson_normalizesNamesAndSignals() throws Exception {
+    RuntimeModeProfile profile =
+        RuntimeProfileCodec.fromJson(
+            """
+            {
+              "loggingMode": " debug ",
+              "tuningEnabled": true,
+              "debugSubsystems": [" Drive ", "VISION"],
+              "loggedSignals": [" voltage ", "position"],
+              "publishedSignals": [" target "]
+            }
+            """);
+
+    assertEquals(GlobalConstants.LoggingMode.DEBUG, profile.loggingMode());
+    assertTrue(profile.tuningEnabled());
+    assertEquals(Set.of("drive", "vision"), profile.debugSubsystems());
+    assertEquals(
+        EnumSet.of(MechanismTelemetry.Signal.VOLTAGE, MechanismTelemetry.Signal.POSITION),
+        profile.loggedSignals());
+    assertEquals(Set.of(MechanismTelemetry.Signal.TARGET), profile.publishedSignals());
+  }
+
+  @Test
+  void fromJson_usesCompetitionDefaultsWhenOptionalFieldsAreOmitted() throws Exception {
+    RuntimeModeProfile profile =
+        RuntimeProfileCodec.fromJson(
+            """
+            {
+              "tuningEnabled": false
+            }
+            """);
+
+    Set<MechanismTelemetry.Signal> expectedSignals =
+        EnumSet.of(
+            MechanismTelemetry.Signal.IDENTITY,
+            MechanismTelemetry.Signal.CONNECTION,
+            MechanismTelemetry.Signal.FAULTS,
+            MechanismTelemetry.Signal.HEALTH,
+            MechanismTelemetry.Signal.TARGET);
+    assertEquals(GlobalConstants.LoggingMode.COMP, profile.loggingMode());
+    assertEquals(expectedSignals, profile.loggedSignals());
+    assertEquals(expectedSignals, profile.publishedSignals());
+  }
+
+  @Test
+  void toJson_roundTripPreservesRuntimeProfile() throws Exception {
+    RuntimeModeProfile original =
+        new RuntimeModeProfile(
+            GlobalConstants.LoggingMode.COMP,
+            true,
+            Set.of("swerve", "vision"),
+            EnumSet.of(MechanismTelemetry.Signal.VOLTAGE, MechanismTelemetry.Signal.CURRENT),
+            EnumSet.of(MechanismTelemetry.Signal.TARGET));
+
+    RuntimeModeProfile decoded = RuntimeProfileCodec.fromJson(RuntimeProfileCodec.toJson(original));
+
+    assertEquals(original, decoded);
+  }
+}


### PR DESCRIPTION
## Phase 0 agentic-harness demonstration

**Harness task:** `DEMO-SEASON2026-JAVA-20260720-03`

### Original request

> Can you improve the test coverage for one of the utilities in our 2026 robot code?

### Clarified specification

Document the current `RuntimeProfileCodec.fromJson` and `toJson` behaviour with valid JUnit
cases for JSON round-trip, case/whitespace normalisation, omitted logging-mode defaults, and
signal-set preservation. Malformed-input policy and production-code changes are out of scope.

### Confirmed plan and scope

- Base: `main` at `7b3c4feac3ce2517f4098bb5e1d8c45a791155b4`
- Head: `b529d3c17c30c176a978f9056549b4da614c4e68`
- In scope: `src/test/java/org/Griffins1884/frc2026/runtime/RuntimeProfileCodecTest.java`
- Out of scope: production Java, motion/safety behaviour, Gradle, workflows, dependencies,
  vendordeps, deploy files, and robot hardware
- Risk: **low**
- Recommended reviewer: **General Code Owners**

### Java changes

Adds three JUnit Jupiter cases:

1. JSON input normalises logging mode, subsystem names, and signal names.
2. Omitted optional fields retain the current competition defaults.
3. `toJson` / `fromJson` round-trip preserves a runtime profile.

No production code changed.

### Validation tied to the head commit

- `./gradlew test --tests "org.Griffins1884.frc2026.runtime.RuntimeProfileCodecTest"` — passed
- `./gradlew spotlessCheck` — passed
- `./gradlew test` — passed
- `./gradlew build` — passed
- GitHub Actions `Build` — passed against the pull-request head
- `AI Full-Diff Review` — passed against the complete base-to-head diff
- Scope check — passed; one planned test file, 72 added lines
- Protected-path check — passed; no protected path in the real diff
- Dry-run protected change — correctly blocked and required Safety Code Owner review

### Learning and review status

- Diff-specific questions generated for the three actual Java test methods
- Student answers: **pending; not supplied by the agent**
- Practical verification: **pending; not supplied by the agent**
- AI full-diff review: **pass at `b529d3c17c30c176a978f9056549b4da614c4e68`; evidence, not approval**
- Human mentor / Code Owner review: **required**

### Rollback

Before merge, delete or reset only this demonstration branch. If merged later, revert
`b529d3c17c30c176a978f9056549b4da614c4e68`.

No robot deployment occurred. No approval or merge is requested from automation. This draft
pull request is Phase 0 demonstration evidence and remains subject to human review.
